### PR TITLE
Refactor choiceset generation

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,5 @@
+^sdr\.log$
+^sa\.log$
+^inst$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ rsconnect/
 # input files
 /inst/example_input
 sdr.log
+sdr_full.log
+sa.log

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stationdemandr
 Type: Package
 Title: Model to forecast demand for new local railway stations
-Version: 0.0.0.9000
+Version: 0.0.1.0
 Authors@R: person("Marcus", "Young", email = "m.a.young@soton.ac.uk", role = c("aut", "cre"))
 Description: This model is intended to forecast demand for new local railway stations. 
   It has been calibrated on all Category E and F stations in mainland GB and incorporates

--- a/R/sdr_calculate_probabilities.R
+++ b/R/sdr_calculate_probabilities.R
@@ -1,13 +1,13 @@
-#' Calculates probabilities for postcode choicesets
+#' Calculates the probabilities for postcode choicesets
 #'
-#' Calculates the probability of each station being chosen within the postcode choicesets
-#' contained in the specified probability table for the proposed station (isolation)
-#' or stations (concurrent). The required columns are created in the table.
-#' @param schema A text string for the database schema name.
-#' @param tablesuffix The suffix of the probability table - either crscode
-#' (isolation) or 'concurrent' (concurrent) is expected.
+#' Calculates the probability of each station being chosen within the postcode
+#' choicesets contained in the specified probability table for the proposed
+#' station (isolation) or stations (concurrent). The required columns are
+#' created in the table.
+#' @param schema Character, the database schema name.
+#' @param tablesuffix Character, the suffix of the probability table - either
+#' crscode (isolation) or 'concurrent' (concurrent) is expected.
 #' @export
-
 
 sdr_calculate_probabilities <- function(schema, tablesuffix) {
 
@@ -35,15 +35,14 @@ sdr_calculate_probabilities <- function(schema, tablesuffix) {
   var_buses <- .75848
 
   # create probability columns
-
   query <-
     paste(
-      "ALTER TABLE ", schema, ".probability_",
+      "alter table ", schema, ".probability_",
       tolower(tablesuffix),
       "
-      ADD COLUMN te19_expv numeric,
-      ADD COLUMN te19_sum_expv numeric,
-      ADD COLUMN te19_prob numeric
+      add column te19_expv numeric,
+      add column te19_sum_expv numeric,
+      add column te19_prob numeric
       "
       ,
       sep = ""
@@ -53,14 +52,13 @@ sdr_calculate_probabilities <- function(schema, tablesuffix) {
                 x = query)
   sdr_dbExecute(con, query)
 
-  #calculate probability
-
+  # calculate probability
   query <-
     paste0(
-      "UPDATE ", schema, ".probability_",
+      "update ", schema, ".probability_",
       tolower(tablesuffix),
       "
-      SET te19_expv =
+      set te19_expv =
       exp(
       (nearest * ", var_nearest ,") +
       (sqr_dist * ", var_sqr_dist ,") +
@@ -77,11 +75,11 @@ sdr_calculate_probabilities <- function(schema, tablesuffix) {
 
   query <-
     paste0(
-      "UPDATE ", schema, ".probability_",
+      "update ", schema, ".probability_",
       tolower(tablesuffix),
-      " SET te19_sum_expv = b.sumexpv from
+      " set te19_sum_expv = b.sumexpv from
       (
-      SELECT id, (sum(te19_expv) OVER (PARTITION BY postcode)) as sumexpv FROM ", schema, ".probability_",
+      select id, (sum(te19_expv) over (partition by postcode)) as sumexpv from ", schema, ".probability_",
       tolower(tablesuffix),
       "
       ) as b
@@ -94,10 +92,10 @@ sdr_calculate_probabilities <- function(schema, tablesuffix) {
 
   query <-
     paste(
-      "UPDATE ", schema, ".probability_",
+      "update ", schema, ".probability_",
       tolower(tablesuffix),
       "
-      SET te19_prob =
+      set te19_prob =
       te19_expv / te19_sum_expv
       ",
       sep = ""
@@ -105,8 +103,7 @@ sdr_calculate_probabilities <- function(schema, tablesuffix) {
   sdr_dbExecute(con, query)
 
  # create indexes
-
-  query <-
+ query <-
     paste(
       "
       create index on ", schema, ".probability_",
@@ -138,5 +135,4 @@ sdr_calculate_probabilities <- function(schema, tablesuffix) {
       sep = ""
     )
   sdr_dbExecute(con, query)
-
 }

--- a/R/sdr_calculate_prweighted_population.R
+++ b/R/sdr_calculate_prweighted_population.R
@@ -55,7 +55,7 @@ sdr_calculate_prweighted_population <- function(schema, crs, tablesuffix) {
       "' and a.distance <= 750 and st_within(b.geom, c.service_area_60mins)
       ), w_pop as (
       select
-      sum(a.te19_prob * b.population * power(((a.distance / 1000) +1), -1.5212)) from ", schema, ".probability_",
+      sum(a.te19_prob * b.population * power((((a.distance - 750) / 1000) +1), -1.5212)) from ", schema, ".probability_",
       tolower(tablesuffix),
       " as a
       left join data.pc_pop_2011 as b on a.postcode = b.postcode
@@ -66,7 +66,7 @@ sdr_calculate_prweighted_population <- function(schema, crs, tablesuffix) {
       ), adj_pop as (
       select sum (
       case when b.distance <=750 then b.te19_prob * a.population
-      when b.distance > 750 then b.te19_prob * a.population * power(((b.distance / 1000) +1), -1.5212)
+      when b.distance > 750 then b.te19_prob * a.population * power((((b.distance - 750) / 1000) +1), -1.5212)
       end)
       from ", schema, ".exogenous_input as a
       left join ", schema, ".probability_",
@@ -101,7 +101,7 @@ sdr_calculate_prweighted_population <- function(schema, crs, tablesuffix) {
       "' and a.distance <= 750
       ), w_pop as (
       select
-      sum(a.te19_prob * b.population * power(((a.distance / 1000) +1), -1.5212)) from ", schema, ".probability_",
+      sum(a.te19_prob * b.population * power((((a.distance - 750) / 1000) +1), -1.5212)) from ", schema, ".probability_",
       tolower(tablesuffix),
       " as a
       left join data.pc_pop_2011 as b on a.postcode = b.postcode
@@ -111,7 +111,7 @@ sdr_calculate_prweighted_population <- function(schema, crs, tablesuffix) {
       ), adj_pop as (
       select sum (
       case when b.distance <=750 then b.te19_prob * a.population
-      when b.distance > 750 then b.te19_prob * a.population * power(((b.distance / 1000) +1), -1.5212)
+      when b.distance > 750 then b.te19_prob * a.population * power((((b.distance - 750) / 1000) +1), -1.5212)
       end)
       from ", schema, ".exogenous_input as a
       left join ", schema, ".probability_",

--- a/R/sdr_calculate_prweighted_population.R
+++ b/R/sdr_calculate_prweighted_population.R
@@ -3,45 +3,43 @@
 #' Calculates the total probability weighted population for a station
 #' by weighting the population of each postcode by the choice
 #' probability for the station and a distance decay function and then summing
-#' across all postcodes. In addition takes account of population data in the
+#' across all postcodes. In addition, takes account of population data in the
 #' exogenous inputs table.
 #'
 #' The calculation is different depending on whether the concurrent or isolation
-#' method is to be used. For concurrent treatment there is only a single probability
-#' table and a spatial query is used so that only those postcodes within the 60 minutes
-#' service area of an individual proposed station are included. This is because a single merged
-#' service area (within 60 minutes of all the stations) was used to generate the postcodes
-#' in the probability table. But only those within 60 minutes of each proposed station
-#' should be considered when generating the weighted population. It is also necessary
-#' to only include the exogenous population for postcodes that fall within a
-#' station's 60-minute service area.
+#' method is to be used. For concurrent treatment there is only a single
+#' probability table and a spatial query is used so that only those postcodes
+#' within the 60 minute service area of an individual proposed station are
+#' included. This is because a single merged service area (within 60 minutes of
+#' all the stations) was used to generate the postcodes in the probability table.
+#' But only those within 60 minutes of each proposed station should be considered
+#' when generating the weighted population. It is also necessary to only include
+#' the exogenous population for postcodes that fall within a station's 60-minute
+#' service area.
 #'
-#' There are 3 CTE queries involved. The first (nw_pop) is population weighted just
-#' by probability when the distance to a station is <= 750m. The second (w_pop) is population
-#' weighted by probability AND by distance decay function. The third (adj_pop) gets
-#' the probability weighted population based on the exogenous data table, applying
-#' the decay function for access distances > 750m.
+#' There are thre CTE queries involved. The first (nw_pop) is population weighted
+#' just by probability when the distance to a station is <= 750m. The second (w_pop)
+#' is population weighted by probability AND by distance decay function. The third
+#' (adj_pop) gets the probability weighted population based on the exogenous data
+#' table, applying the decay function for access distances > 750m.
 #'
-#' For stations treated in isolation the FROM table for nw_pop and w_pop is the probability table for that
-#' station and census postcode population is joined by a left join, so only relevant
-#' postcodes will ever be included. In the case of adj_pop the from table is the exogenous table
-#' and the probability is left joined from the probability table. This will be null if the postcode
-#' is not present in the probability table and it will not in those circumstances contribute to the sum.
-#' As in SQL NULL times anything is NULL.
+#' For stations treated in isolation the FROM table for nw_pop and w_pop is the
+#' probability table for that station and census postcode population is joined
+#' by a left join, so only relevant postcodes will ever be included. In the case
+#' of adj_pop the from table is the exogenous table and the probability is left
+#' joined from the probability table. This will be null if the postcode is not
+#' present in the probability table and it will not in those circumstances
+#' contribute to the sum - as in SQL, NULL times anything is NULL.
 #'
-#' @param schema A text string for the database schema name.
-#' @param crs The crscode of the station.
-#' @param tablesuffix The suffix of the probability table - either crscode
-#' (isolation) or 'concurrent' (concurrent) is expected.
+#' @param schema Character, the database schema name.
+#' @param crs Character, the crscode of the station.
+#' @param tablesuffix Character, the suffix of the probability table - either
+#' crscode (isolation) or 'concurrent' (concurrent) is expected.
 #' @export
 sdr_calculate_prweighted_population <- function(schema, crs, tablesuffix) {
-
-
-  if (tablesuffix == "concurrent") {
-
-    futile.logger::flog.info(paste0("Getting probability weighted population for: ", crs, ", from: probability_", tolower(tablesuffix)))
-
-    query <- paste0(
+if (tablesuffix == "concurrent") {
+  futile.logger::flog.info(paste0("Getting probability weighted population for: ", crs, ", from: probability_", tolower(tablesuffix)))
+  query <- paste0(
       "
       with nw_pop as(
       select
@@ -65,7 +63,7 @@ sdr_calculate_prweighted_population <- function(schema, crs, tablesuffix) {
       "' and a.distance > 750 and st_within(b.geom, c.service_area_60mins)
       ), adj_pop as (
       select sum (
-      case when b.distance <=750 then b.te19_prob * a.population
+      case when b.distance <= 750 then b.te19_prob * a.population
       when b.distance > 750 then b.te19_prob * a.population * power((((b.distance - 750) / 1000) +1), -1.5212)
       end)
       from ", schema, ".exogenous_input as a
@@ -85,9 +83,7 @@ sdr_calculate_prweighted_population <- function(schema, crs, tablesuffix) {
       )
     result <- sdr_dbGetQuery(con, query)
   } else {
-
     futile.logger::flog.info(paste0("Getting probability weighted population for: ", crs, ", from: probability_", tolower(tablesuffix)))
-
     query <- paste0(
       "
       with nw_pop as(
@@ -127,6 +123,5 @@ sdr_calculate_prweighted_population <- function(schema, crs, tablesuffix) {
       )
     result <- sdr_dbGetQuery(con, query)
   }
-
 return(as.numeric(result))
 }

--- a/R/sdr_create_service_areas.R
+++ b/R/sdr_create_service_areas.R
@@ -29,8 +29,9 @@ total_stations <- nrow(df)
 
 # begin the service area loop i
 df <- foreach::foreach(i=sa, .noexport="con", .packages=c("DBI", "RPostgres", "dplyr")) %dopar%
-{
 
+  {
+  sink("sa.log", append=TRUE)
   if (cost == "len") {
     column_name <- paste0("service_area_", i / 1000, "km")
     # for distance set buffer to same as distance - not possible for road

--- a/R/sdr_create_service_areas.R
+++ b/R/sdr_create_service_areas.R
@@ -1,163 +1,193 @@
 #' Creates a distance or time based network service area around stations
 #'
 #' Creates a distance or time based network service area around stations in
-#' the provided data frame using the pgRouting function \code{pgr_withpointsdd}. The
-#' service area geometry is written to the specified database \code{table} in the
-#' specified database \code{schema}.The supplied \code{identifier} links the stations
-#' in the data frame and the database table.
+#' the provided data frame using the pgRouting function \code{pgr_withpointsdd}.
+#' The service area geometry is written to the specified database \code{table}
+#' in the specified database \code{schema}. The supplied \code{identifier} links
+#' the stations in the data frame and the database table. Uses parallel processing.
 #'
-#' @param schema A text string for the database schema name.
-#' @param df A dataframe with a column named "location"
+#' @param schema Character, the database schema name.
+#' @param df A data frame with a column named "location"
 #' which has the easting and northing of the station location.
-#' @param identifier A text string which uniquely identifies
-#' a station in both the provided dataframe \emph{and} in the target \code{table}.
-#' @param sa A vector of integer values for the required service areas. Should
-#' be in metres when cost is distance and minutes when cost is time.
-#' @param table A text string for the target database table name.
-#' @param cost A text string, either "len" for a distance-based service area or
+#' @param identifier Character, uniquely identifies a station in both the
+#' provided data frame \emph{and} in the target \code{table}.
+#' @param sa Numeric vector of integer values for the required service areas.
+#' Should be in metres when cost is distance and minutes when cost is time.
+#' @param table Character, the target database table name.
+#' @param cost Character, either "len" for a distance-based service area or
 #' "time" for a time-based service area. Default is "len".
-#' @param target The target percent of area of convex hull that ST_ConvexHull
-#' will try to approach before giving up or exiting. Default is 0.9.
+#' @param target Numeric, the target percent of area of convex hull that
+#' ST_ConvexHull will try to approach before giving up or exiting. Default is 0.9.
 #' @export
-sdr_create_service_areas <- function(schema, df, identifier, sa, table, cost = "len", target = 0.9) {
+sdr_create_service_areas <-
+  function(schema,
+           df,
+           identifier,
+           sa,
+           table,
+           cost = "len",
+           target = 0.9) {
+    # set number of records
+    total_stations <- nrow(df)
 
-# set number of records
-total_stations <- nrow(df)
+    # begin the service area loop i
+    df <-
+      foreach::foreach(
+        i = sa,
+        .noexport = "con",
+        .packages = c("DBI", "RPostgres", "dplyr")
+      ) %dopar%
+      {
+        # futile.logger can't write to sdr.log within a foreach
+        # there'd probably a solution but a workaround is to specify sink() to
+        # another file and futile.logger will log to this.
+        sink("sa.log", append = TRUE)
+        if (cost == "len") {
+          column_name <- paste0("service_area_", i / 1000, "km")
+          # for distance set buffer to same as distance - not possible for road
+          # distance to go beyond straight line distance
+          buffer <- i
+        } else if (cost == "time") {
+          column_name <- paste0("service_area_", i, "mins")
+          # for time set the buffer to 105000. The fastest road speed
+          # in roadlinks is 65 mph (105 kmph) so thereotical maximum distance
+          # that can be acheived in one hour is 105 km
+          buffer <- 105000
+        } else {
+          stop("Cost type does not exist")
+        }
 
+        # create sa column in table
+        query <-
+          paste0(
+            "alter table ",
+            paste0(schema, '.', table),
+            " add column if not exists ",
+            column_name,
+            " geometry(Polygon,27700);"
+          )
+        sdr_dbExecute(con, query)
 
+        # Note that the pid provided in the virtual node sql to pgr_withpointsdd
+        # must be negative for the virtual nodes to be included when searching
+        # for nodes within driving distance. We want these included as they
+        # provide extra nodes on roads with few intersections (e.g. motorways).
+        # Also note: in this use-case virtual nodes cannot then be used as source
+        # nodes. The source node is therefore taken as the nearest real node on the
+        # nearest edge to the station. This node is found using pgr_pointtoedgenode,
+        # with a maximum 1000 km tolerance to nearest edge.
 
-
-# begin the service area loop i
-df <- foreach::foreach(i=sa, .noexport="con", .packages=c("DBI", "RPostgres", "dplyr")) %dopar%
-
-  {
-  # futile.logger can't write to sdr.log within foreach
-  # there probably is a solution but for now workaround is to specify sink() to
-  # another file and futile.logger will log to this.
-  sink("sa.log", append=TRUE)
-  if (cost == "len") {
-    column_name <- paste0("service_area_", i / 1000, "km")
-    # for distance set buffer to same as distance - not possible for road
-    # distance to go beyond straight line distance
-    buffer <- i
-  } else if (cost == "time") {
-    column_name <- paste0("service_area_", i, "mins")
-    # for time set the buffer to 105000. The fastest road speed
-    # in roadlinks is 65mph (105 kmph) so thereotical maximum distance
-    # that can be acheived in one hour is 105km
-    buffer <- 105000
-  } else {
-    stop("cost type does not exist")
-  }
-
-  # create sa column in table
-
-  query <-
-    paste0(
-      "alter table ", paste0(schema, '.', table), " add column if not exists ",
-      column_name,
-      " geometry(Polygon,27700);"
-    )
-  sdr_dbExecute(con, query)
-
-  ## Note the pid provided in the virtual node sql to pgr_withpointsdd must be negative
-  ## for the virtual nodes to be included when searching for nodes within driving distance.
-  ## Also note: in this case virtual nodes cannot then be used as source nodes
-  ## Source node is taken as the nearest real node on the nearest edge to the station.
-  ## This node is found using pgr_pointtoedgenode, with a maximum 1000km tolerance to nearest edge.
-
-  # Begin the stations loop j
-  for (j in 1:total_stations) {
-
-    futile.logger::flog.info(paste0("creating ", column_name, " for ", df[j, paste0(identifier)]))
-    query <- paste0(
-      "with tmp as
+        # Begin the stations loop j
+        for (j in 1:total_stations) {
+          futile.logger::flog.info(paste0("creating ", column_name, " for ", df[j, paste0(identifier)]))
+          query <- paste0(
+            "with tmp as
       (
       select dd.node, coalesce(a.the_geom, b.the_geom) as the_geom
       from
       pgr_withpointsdd($sql$
-      select id, source, target, cost_", cost, " as cost
+      select id, source, target, cost_",
+            cost,
+            " as cost
       from openroads.roadlinks where the_geom && st_buffer(st_setsrid(st_point(",
-      df$location[j] ,
-      "), 27700),",
-      buffer ,
-      ")$sql$,
+            df$location[j] ,
+            "), 27700),",
+            buffer ,
+            ")$sql$,
       $sql2$select pid, edge_id, fraction from openroads.vnodesneg_roadlinks$sql2$,
       pgr_pointtoedgenode($str1$openroads.roadlinks$str1$, st_setsrid(st_point(",
-      df$location[j] ,
-      "), 27700), 1000),",
-      i ,
-      ", false)
+            df$location[j] ,
+            "), 27700), 1000),",
+            i ,
+            ", false)
       as dd
       left join openroads.roadnodes as a on dd.node = a.id
       left join openroads.vnodesneg_roadlinks as b on dd.node = -b.pid
       order by node
       )
-      update ", paste0(schema, '.', table), " set ",
-      column_name ,
-      " = sa.geom  FROM (
-      SELECT 1 as id, ST_ConcaveHull(ST_Collect(the_geom), ", target, " ) as geom from tmp) as sa
-      WHERE ", identifier, " = '",
-      df[j, paste0(identifier)] ,
-      "';"
-    )
-    sdr_dbExecute(con, query)
+      update ",
+            paste0(schema, '.', table),
+            " set ",
+            column_name ,
+            " = sa.geom  FROM (
+      SELECT 1 as id, ST_ConcaveHull(ST_Collect(the_geom), ",
+            target,
+            " ) as geom from tmp) as sa
+      WHERE ",
+            identifier,
+            " = '",
+            df[j, paste0(identifier)] ,
+            "';"
+          )
+          sdr_dbExecute(con, query)
 
-    # check for null service area returned  - a potential problem with ST_ConcaveHull with
-    # target < 1
-    # If null, repeat with target set to 1
+          # check for null service area returned  - a potential problem with
+          # ST_ConcaveHull when target < 1
+          # If null, repeat with target set to 1
+          query <-
+            paste0(
+              "select location from " ,
+              paste0(schema, '.', table),
+              " where ",
+              column_name,
+              " is null and ",
+              identifier,
+              " = '",
+              df[j, paste0(identifier)],
+              "'"
+            )
+          stations_null <- sdr_dbGetQuery(con, query)
 
-    query <-
-      paste0(
-        "select location from " , paste0(schema, '.', table), " where ", column_name, " is null and ", identifier, " = '", df[j, paste0(identifier)], "'"
-      )
-
-    stations_null <- sdr_dbGetQuery(con, query)
-
-    total_null <- nrow(stations_null) # set number of records
-
-    if (total_null > 0) {
-
-      futile.logger::flog.info(paste0("null returned for ", column_name, " for ", df[j, paste0(identifier)], ": re-running with target = 1"))
-
-      query <- paste0(
-        "with tmp as
+          total_null <- nrow(stations_null) # set number of records
+          if (total_null > 0) {
+            futile.logger::flog.info(
+              paste0(
+                "null returned for ",
+                column_name,
+                " for ",
+                df[j, paste0(identifier)],
+                ": re-running with target = 1"
+              )
+            )
+            query <- paste0(
+              "with tmp as
       (
       select dd.node, coalesce(a.the_geom, b.the_geom) as the_geom
       from
       pgr_withpointsdd($sql$
-      select id, source, target, cost_", cost, " as cost
+      select id, source, target, cost_",
+              cost,
+              " as cost
       from openroads.roadlinks where the_geom && st_buffer(st_setsrid(st_point(",
-        df$location[j] ,
-        "), 27700),",
-        buffer ,
-        ")$sql$,
+              df$location[j] ,
+              "), 27700),",
+              buffer ,
+              ")$sql$,
       $sql2$select pid, edge_id, fraction from openroads.vnodesneg_roadlinks$sql2$,
       pgr_pointtoedgenode($str1$openroads.roadlinks$str1$, st_setsrid(st_point(",
-        df$location[j] ,
-        "), 27700), 1000),",
-        i ,
-        ", false)
+              df$location[j] ,
+              "), 27700), 1000),",
+              i ,
+              ", false)
       as dd
       left join openroads.roadnodes as a on dd.node = a.id
       left join openroads.vnodesneg_roadlinks as b on dd.node = -b.pid
       order by node
       )
-      update ", paste0(schema, '.', table), " set ",
-        column_name ,
-        " = sa.geom  FROM (
+      update ",
+              paste0(schema, '.', table),
+              " set ",
+              column_name ,
+              " = sa.geom  FROM (
       SELECT 1 as id, ST_ConcaveHull(ST_Collect(the_geom), 1) as geom from tmp) as sa
-      WHERE ", identifier, " = '",
-        df[j, paste0(identifier)] ,
-        "';"
-      )
-      sdr_dbExecute(con, query)
-
-    }
-
-  }
-}
-
-# end function
-}
-
+      WHERE ",
+              identifier,
+              " = '",
+              df[j, paste0(identifier)] ,
+              "';"
+            )
+            sdr_dbExecute(con, query)
+          }
+        }
+      } # end %dopar%
+  } # end function

--- a/R/sdr_create_service_areas.R
+++ b/R/sdr_create_service_areas.R
@@ -31,6 +31,9 @@ total_stations <- nrow(df)
 df <- foreach::foreach(i=sa, .noexport="con", .packages=c("DBI", "RPostgres", "dplyr")) %dopar%
 
   {
+  # futile.logger can't write to sdr.log within foreach
+  # there probably is a solution but for now workaround is to specify sink() to
+  # another file and futile.logger will log to this.
   sink("sa.log", append=TRUE)
   if (cost == "len") {
     column_name <- paste0("service_area_", i / 1000, "km")

--- a/R/sdr_create_service_areas.R
+++ b/R/sdr_create_service_areas.R
@@ -28,7 +28,7 @@ total_stations <- nrow(df)
 
 
 # begin the service area loop i
-df <- foreach::foreach(i=sa, .noexport="con", .packages=c("DBI", "RPostgreSQL", "dplyr")) %dopar%
+df <- foreach::foreach(i=sa, .noexport="con", .packages=c("DBI", "RPostgres", "dplyr")) %dopar%
 {
 
   if (cost == "len") {

--- a/R/sdr_frequency_group_adjustment.R
+++ b/R/sdr_frequency_group_adjustment.R
@@ -4,12 +4,12 @@
 #' stations (concurrent), adjusting the frequency variable for existing stations
 #' based on information provided in the frequency group input file.
 #'
-#' @param schema A text string for the database schema name.
+#' @param schema Character, the database schema name.
 #' @param df A data frame containing the frequency group input. In isolation mode
 #' this will relate to a specific station. In concurrent mode there will only be
 #' a single frequency group across all stations.
-#' @param tablesuffix The suffix of the probability table to be updated - either a crscode
-#' (isolation) or 'concurrent' (concurrent) is expected.
+#' @param tablesuffix Character, the suffix of the probability table to be
+#' updated - either a crscode (isolation) or 'concurrent' (concurrent) is expected.
 #' @export
 sdr_frequency_group_adjustment <- function(schema, df, tablesuffix) {
   # count number of stations in the frequency group

--- a/R/sdr_generate_choicesets.R
+++ b/R/sdr_generate_choicesets.R
@@ -251,7 +251,7 @@ sdr_generate_choicesets <-
       foreach::foreach(
         i = postcodes$postcode,
         .noexport = "con",
-        .packages = c("DBI", "RPostgreSQL", "dplyr"),
+        .packages = c("DBI", "RPostgres", "dplyr"),
         .combine = 'rbind'
       ) %dopar%
       {

--- a/R/sdr_generate_choicesets.R
+++ b/R/sdr_generate_choicesets.R
@@ -110,7 +110,7 @@ sdr_generate_choicesets <-
       from
       data.pc_pop_2011 a, sa where st_within(a.geom, sa.geom)
       "
-      )
+    )
     postcodes <- sdr_dbGetQuery(con, query)
 
 
@@ -184,7 +184,7 @@ sdr_generate_choicesets <-
       from
       tmp
       "
-      )
+    )
     sdr_dbExecute(con, query)
 
 
@@ -234,7 +234,7 @@ sdr_generate_choicesets <-
       ,
       ")
       "
-      )
+    )
     sdr_dbExecute(con, query)
 
     # generate choicesets using parallel processing
@@ -265,7 +265,7 @@ sdr_generate_choicesets <-
           paste(crs, sep = "", collapse = ", "),
           "', 1000, 0.5)
           "
-          )
+        )
         nearestx <- sdr_dbGetQuery(con, query)
 
         if (nrow(nearestx) > 0) {
@@ -284,7 +284,7 @@ sdr_generate_choicesets <-
               nearestx$crscode[j],
               "', 25000, 1)
               "
-              )
+            )
             d <- sdr_dbGetQuery(con, query)
             # check if a distance is returned
             if (nrow(d) > 0) {
@@ -302,7 +302,7 @@ sdr_generate_choicesets <-
                 nearestx$crscode[j],
                 "')
                 "
-                )
+              )
               d <- sdr_dbGetQuery(con, query)
               # just in case still no result trap and use -9999
               # how to deal with this??
@@ -376,29 +376,46 @@ sdr_generate_choicesets <-
       futile.logger::flog.info(paste0("Unique postcodes: ", length(unique(df$postcode))))
     }
 
-    # log some choiceset stats
-    futile.logger::flog.info(paste0(
-      "average choiceset size: ",
-      df %>%
-        dplyr::summarise(number = n()) %>%
-        dplyr::summarise(mean(number))
-    ))
-    futile.logger::flog.info(paste0(
-      "min choiceset size: ",
-      df %>%
-        dplyr::summarise(number = n()) %>%
-        dplyr::summarise(min(number))
-    ))
-    futile.logger::flog.info(paste0(
-      "max choiceset size: ",
-      df %>%
-        dplyr::summarise(number = n()) %>%
-        dplyr::summarise(max(number))
-    ))
+    avg_choiceset_size <- df %>%
+      dplyr::summarise(number = n()) %>%
+      dplyr::summarise(mean(number))
+
+    min_choiceset_size <- df %>%
+      dplyr::summarise(number = n()) %>%
+      dplyr::summarise(min(number))
+
+    max_choiceset_size <- df %>%
+      dplyr::summarise(number = n()) %>%
+      dplyr::summarise(max(number))
+
+    # info or warnings re choiceset dimensions
+
+    if (avg_choiceset_size < 10 |
+        max_choiceset_size > 10 | min_choiceset_size < 10) {
+      futile.logger::flog.warn(
+        paste0(
+          "Choiceset dimensions outside of expected values. Average size: ",
+          avg_choiceset_size,
+          "; maximum size: ",
+          max_choiceset_size,
+          "; minimum size: ",
+          min_choiceset_size
+        )
+      )
+    } else {
+      # log some choiceset stats
+      futile.logger::flog.info(paste0("average choiceset size: ",
+                                      avg_choiceset_size))
+      futile.logger::flog.info(paste0("min choiceset size: ",
+                                      min_choiceset_size))
+      futile.logger::flog.info(paste0("max choiceset size: ",
+                                      max_choiceset_size))
+    }
+
 
     df <- dplyr::ungroup(df)
 
     return(df)
 
     #end function
-    }
+  }

--- a/R/sdr_generate_choicesets.R
+++ b/R/sdr_generate_choicesets.R
@@ -281,7 +281,7 @@ sdr_generate_choicesets <- function(schema, crs, existing = FALSE , abs_crs = NU
 
   futile.logger::flog.info(paste0("Set of choicesets generated for: ", paste0(pc_crs, collapse = ", ")))
   futile.logger::flog.info(paste0("Rows: ", nrow(df)))
-  futile.logger::flog.info(paste0("removing all rows for any postcode where none of: ", paste0(pc_crs, collapse = ", ")))
+  futile.logger::flog.info(paste0("Removing all rows for any postcode where none of: ", paste0(pc_crs, collapse = ", ")))
 
   df <- df %>%
     dplyr::group_by(postcode) %>%

--- a/R/sdr_generate_choicesets.R
+++ b/R/sdr_generate_choicesets.R
@@ -1,59 +1,62 @@
 #' Generates a choice set of ten nearest stations for postcodes
 #'
 #' For a given station or stations identifies the postcodes within 60 minutes of
-#' the station or stations and then generates a choice set of the nearest 10 stations to each of those
-#' postcodes. The function is also able to generate before and after choicesets for abstraction analysis.
+#' the station or stations and then generates a choice set of the nearest 10
+#' stations to each of those postcodes. The function is also able to generate
+#' before and after choicesets for abstraction analysis.
 #'
-#' If existing is set to \code{FALSE} then the crscodes in \code{crs} must be proposed
-#' stations. The function will obtain the 60 minute service area geometry from the
-#' modelschema.proposed_stations table. If there is more than one crscode in \code{crs} then
-#' st_union will be applied to the individual service area geometries to create a
-#' single merged 60 minute service area (this is used when the concurrent mode has
-#' been selected for the model run).
+#' If \code{existing} is set to FALSE then the crscode(s) in \code{crs} must be
+#' for proposed stations. The function obtains the 60 minute service area geometry
+#' from the schema.proposed_stations table. If there is more than one crscode in
+#' \code{crs} then st_union will be applied to the individual service area
+#' geometries to create a single merged 60 minute service area (this is used when
+#' the concurrent mode has been selected for the model run). The function uses
+#' parallel processing via the foreach package and requires the clusters to be
+#' configured prior to calling the function.
 #'
-#' If existing is set to \code{TRUE} then the crscodes in \code{crs} must be existing
-#' stations (normally a single station). The function will obtain the 60 minute service
-#' area geometry from the data.stations table.
+#' If \code{existing} is set to TRUE then the crscode(s) in \code{crs} must be
+#' existing stations (normally a single station). The function will obtain the
+#' 60 minute service area geometry from the data.stations table.
 #'
 #' If \code{abs_crs} is passed to the function then it should be a single crscode
-#' of an existing station. This is used to control whether a before or after set of
-#' postcode choicesets is required. To obtain a before choiceset for abstraction analysis
-#' pass the existing station crscode to the function using \code{crs}, set \code{existing}
-#' to \code{TRUE} and do not pass \code{abs_crs}. To obtain an after choiceset for
-#' abstraction analysis pass the proposed station(s) in \code{crs}, set \code{existing}
-#' to \code{FALSE} and pass the crscode of the existing station for which abstraction analysis
-#' is being carried out to \code{abs_crs}.
+#' of an existing station. This is used to control whether a before or after set
+#' of postcode choicesets is required. To obtain a before choiceset for
+#' abstraction analysis pass the existing station crscode to the function using
+#' \code{crs}, set \code{existing} to TRUE and do not pass \code{abs_crs}. To
+#' obtain an after choiceset for abstraction analysis pass the proposed station(s)
+#' in \code{crs}, set \code{existing} to FALSE and pass the crscode of the
+#' existing station for which abstraction analysis is being carried out to
+#' \code{abs_crs}.
 #'
-#' The function uses parallel processing via the foreach package and requires
-#' the clusters to be configured prior to calling the function.
-#'
-#' The function submits db queries which rely on several pgRouting wrapper functions that must be
-#' located in the openroads schema: \code{create_pgr_vnodes},
+#' The function submits db queries which rely on several bespoke pgRouting wrapper
+#' functions that must be located in the openroads schema: \code{create_pgr_vnodes},
 #' \code{sdr_crs_pc_nearest_stationswithpoints}, \code{sdr_pc_station_withpoints},
 #' \code{sdr_pc_station_withpoints_nobbox}, and \code{bbox_pgr_withpointscost}.
 #'
-#' Two views are created for use by these functions. The first is modelschema.centroidnodes
-#' which is a union of virtual nodes for the proposed stations (which are created in the query)
-#' and virtual nodes for existing stations. The second is modelschema.stations which is a union of
-#' stations from data.stations and modelschema.proposed_stations containing the distance-based
-#' service areas used in identfying the nearest 10 stations to each postcode.
+#' Two views are created for use by these functions. The first is schema.centroidnodes
+#' which is a union of virtual nodes for the proposed stations (which are created
+#' in the query) and virtual nodes for existing stations. The second is
+#' schema.stations which is a union of stations from data.stations and
+#' schema.proposed_stations containing the distance-based service areas used in
+#' identfying the nearest 10 stations to each postcode.
 #'
 #' For maximum flexibility to also use this function for abstraction analysis
 #' without code repetition, it should be noted that the union queries are
-#' used even when \code{existing} is set to \code{TRUE} and the crscode in \code{crs} is
-#' an existing station. In this case there will be no match with the stations in
-#' modelschema.proposed_stations and that part of the union query will simply return null.
+#' used even when \code{existing} is set to TRUE and the crscode in \code{crs} is
+#' an existing station. In this case there will be no match with any stations in
+#' schema.proposed_stations and that part of the union query will simply return
+#' null.
 #'
-#' @param schema A text string for the database schema name.
-#' @param crs A character vector of the crscode(s) of the station(s)
+#' @param schema Character, the database schema name.
+#' @param crs Character vector of the crscode(s) of the station(s)
 #' for which a set of postcode choicesets is required.
 #' @param existing Logical. Indicates whether the station crscodes contained in
-#' \code{crs} are for existing (\code{TRUE}) or proposed (\code{FALSE}) stations.
-#' Default is \code{FALSE}.
-#' @param abs_crs Character. A single crs code of an existing station for which an
-#' after set of postcode choicesets is required. Optional.
-#' @return Returns a data frame containing the postcode choicesets with stations ranked
-#' by distance.
+#' \code{crs} are for existing (TRUE) or proposed (FALSE) stations.
+#' Default is FALSE.
+#' @param abs_crs Character, a single crs code of an existing station for which
+#' an after set of postcode choicesets is required. Optional.
+#' @return Returns a data frame containing the postcode choicesets with stations
+#' ranked by distance from the postcode centroid.
 #' @importFrom foreach %dopar%
 #' @export
 sdr_generate_choicesets <-
@@ -68,25 +71,22 @@ sdr_generate_choicesets <-
     } else {
       pc_crs = abs_crs
     }
-
     futile.logger::flog.info(paste0(
       "Set of postcode choice sets is required for: ",
       paste0(pc_crs, collapse = ", ")
     ))
 
     # Set the table to be used to get the service area geometry.
-    # If existing is TRUE always use modelschema.proposed_stations. Otherwise
+    # If existing is TRUE always use schema.proposed_stations. Otherwise
     # it depends on whether abs_crs is specified or not.
-    if (existing == TRUE) {
+    if (isTRUE(existing)) {
       pc_table = "data.stations"
     } else if (is.null(abs_crs)) {
       pc_table = paste0(schema, ".proposed_stations")
     } else {
       pc_table = "data.stations"
     }
-
     futile.logger::flog.info(paste0("Using service area geometry from: ", pc_table))
-
     futile.logger::flog.info(paste0(
       "Getting postcodes within 60 minute service area of: ",
       paste0(pc_crs, collapse = ", ")
@@ -113,18 +113,17 @@ sdr_generate_choicesets <-
     )
     postcodes <- sdr_dbGetQuery(con, query)
 
-
-
-    # Need to create virtual nodes for new stations.
-    # Create view of nodes table union with the new stations
+    # Need to create virtual nodes for proposed station(s).
+    # Create view of nodes table union with the proposed station(s)
     # including all existing stations but only the postcode nodes
     # that are needed, i.e. within the sa (so query above is used again in
     # the where statement).
-    # First CTE (tmp) is getting virtual nodes for the proposed station(s);
-    # then select the station and relevant postcode nodes from openroads.centroidnodes;
-    # then union all select the virtual node information from tmp.
+    # The first CTE (tmp) is getting virtual nodes for the proposed station(s);
+    # then select the station and relevant postcode nodes from
+    # openroads.centroidnodes; then union all select the virtual node information
+    # from tmp.
 
-    futile.logger::flog.info("creating virtual nodes table")
+    futile.logger::flog.info("Creating virtual nodes table")
 
     query <- paste0(
       "create or replace view ",
@@ -173,7 +172,7 @@ sdr_generate_choicesets <-
       select
       reference,
       case
-      when pid =- 1 then
+      when pid = -1 then
       ( id + 40000000 ) * pid else pid
       end as pid,
       type,
@@ -187,11 +186,9 @@ sdr_generate_choicesets <-
     )
     sdr_dbExecute(con, query)
 
-
     # create view of existing and proposed station(s)
-
     futile.logger::flog.info(paste0(
-      "creating stations view for existing stations and: ",
+      "Creating stations view for existing stations and: ",
       paste0(crs, collapse = ", ")
     ))
 
@@ -238,15 +235,13 @@ sdr_generate_choicesets <-
     sdr_dbExecute(con, query)
 
     # generate choicesets using parallel processing
-
     futile.logger::flog.info(
       paste0(
-        "starting parallel processing to generate the choicesets for ",
+        "Starting parallel processing to generate the choicesets for ",
         nrow(postcodes),
         " postcodes"
       )
     )
-
     df <-
       foreach::foreach(
         i = postcodes$postcode,
@@ -267,11 +262,13 @@ sdr_generate_choicesets <-
           "
         )
         nearestx <- sdr_dbGetQuery(con, query)
-
+        # sdr_crs_pc_nearest_stationswithpoints() will return null if no
+        # station in crs is present in the nearest 10 (or more) stations
+        # this avoids unnecessary distance lookups. Therefore, need to check
+        # rows returned are > 0 before
         if (nrow(nearestx) > 0) {
-          # check for nulls. If present
-          # make individual function call for each specific postcode:station pair
-          # with larger bounding box.
+          # check for distance NAs. If present make individual function call for
+          # each affected postcode:station pair with a larger bounding box.
           for (j in which(is.na(nearestx$distance))) {
             query <- paste0(
               "
@@ -305,32 +302,19 @@ sdr_generate_choicesets <-
               )
               d <- sdr_dbGetQuery(con, query)
               # just in case still no result trap and use -9999
-              # how to deal with this??
               if (nrow(d) > 0) {
                 nearestx$distance[j] <- d$distance
               } else {
                 nearestx$distance[j] <- -9999
-                futile.logger::flog.warn(
-                  "A distance could not be obtained between ",
-                  nearestx$postcode[j],
-                  " and ",
-                  nearestx$crscode[j]
-                )
               }
             }
-
-          } # end for each null station
-
+          } # end for distance NA
           choiceset <-
             nearestx %>% dplyr::mutate("distance_rank" = dplyr::row_number(distance)) %>%
             dplyr::filter(distance_rank <= 10) %>%
             dplyr::arrange(distance_rank)
-
-
-        }  # end if nearestx not empty
-
-      } # end foreach postcode parallel processing
-
+          } # end if nearestx not empty
+        } # end foreach postcode parallel processing
 
     # remove rows (i.e. the choiceset) for any postcodes where none of the crscodes
     # are in the choiceset
@@ -345,8 +329,9 @@ sdr_generate_choicesets <-
     ))
     df <- df %>%
       dplyr::group_by(postcode) %>%
-      #filter(any(...)) evaluates at the group_by() level
+      # note: dplyr filter(any(...)) evaluates at the group_by() level
       dplyr::filter(any(crscode %in% pc_crs))
+
     futile.logger::flog.info(paste0("Rows: ", nrow(df)))
     futile.logger::flog.info(paste0("Unique postcodes: ", length(unique(df$postcode))))
 
@@ -368,7 +353,7 @@ sdr_generate_choicesets <-
           )
         )
       futile.logger::flog.warn(msg)
-      # now filter to remove postcodes that do not contain a -9999 distance
+      # now filter to remove postcodes that contain a -9999 distance
       df <- df %>%
         dplyr::filter(!any(distance == -9999))
 
@@ -376,20 +361,18 @@ sdr_generate_choicesets <-
       futile.logger::flog.info(paste0("Unique postcodes: ", length(unique(df$postcode))))
     }
 
+    # get some choiceset stats
     avg_choiceset_size <- df %>%
       dplyr::summarise(number = n()) %>%
       dplyr::summarise(mean(number))
-
     min_choiceset_size <- df %>%
       dplyr::summarise(number = n()) %>%
       dplyr::summarise(min(number))
-
     max_choiceset_size <- df %>%
       dplyr::summarise(number = n()) %>%
       dplyr::summarise(max(number))
 
     # info or warnings re choiceset dimensions
-
     if (avg_choiceset_size < 10 |
         max_choiceset_size > 10 | min_choiceset_size < 10) {
       futile.logger::flog.warn(
@@ -403,7 +386,7 @@ sdr_generate_choicesets <-
         )
       )
     } else {
-      # log some choiceset stats
+      # log the choiceset stats
       futile.logger::flog.info(paste0("average choiceset size: ",
                                       avg_choiceset_size))
       futile.logger::flog.info(paste0("min choiceset size: ",
@@ -412,10 +395,8 @@ sdr_generate_choicesets <-
                                       max_choiceset_size))
     }
 
-
+    # remove the postcode grouping from df
     df <- dplyr::ungroup(df)
-
     return(df)
-
     #end function
   }

--- a/R/sdr_generate_choicesets.R
+++ b/R/sdr_generate_choicesets.R
@@ -56,263 +56,349 @@
 #' by distance.
 #' @importFrom foreach %dopar%
 #' @export
-sdr_generate_choicesets <- function(schema, crs, existing = FALSE , abs_crs = NULL ) {
+sdr_generate_choicesets <-
+  function(schema,
+           crs,
+           existing = FALSE ,
+           abs_crs = NULL) {
+    # Set which station the set of postcode choicesets is required for
+    # This will be the content of crs, or abs_crs if it is specified.
+    if (is.null(abs_crs)) {
+      pc_crs = crs
+    } else {
+      pc_crs = abs_crs
+    }
 
-  # Set which station the set of postcode choicesets is required for
-  # This will be the content of crs, or abs_crs if it is specified.
-  if (is.null(abs_crs)) {
-    pc_crs = crs
-  } else {
-    pc_crs = abs_crs
-  }
+    futile.logger::flog.info(paste0(
+      "Set of postcode choice sets is required for: ",
+      paste0(pc_crs, collapse = ", ")
+    ))
 
-  futile.logger::flog.info(paste0("Set of postcode choice sets is required for: ", paste0(pc_crs, collapse = ", ")))
+    # Set the table to be used to get the service area geometry.
+    # If existing is TRUE always use modelschema.proposed_stations. Otherwise
+    # it depends on whether abs_crs is specified or not.
+    if (existing == TRUE) {
+      pc_table = "data.stations"
+    } else if (is.null(abs_crs)) {
+      pc_table = paste0(schema, ".proposed_stations")
+    } else {
+      pc_table = "data.stations"
+    }
 
-  # Set the table to be used to get the service area geometry.
-  # If existing is TRUE always use modelschema.proposed_stations. Otherwise
-  # it depends on whether abs_crs is specified or not.
-  if (existing == TRUE) {
-    pc_table = "data.stations"
-  } else if (is.null(abs_crs)) {
-    pc_table = paste0(schema, ".proposed_stations")
-  } else {
-    pc_table = "data.stations"
-  }
+    futile.logger::flog.info(paste0("Using service area geometry from: ", pc_table))
 
-  futile.logger::flog.info(paste0("Using service area geometry from: ", pc_table))
+    futile.logger::flog.info(paste0(
+      "Getting postcodes within 60 minute service area of: ",
+      paste0(pc_crs, collapse = ", ")
+    ))
 
-  futile.logger::flog.info(paste0("Getting postcodes within 60 minute service area of: ", paste0(pc_crs, collapse = ", ")))
-
-  # Get postcodes within the applicable 60 minute service area
-  query <- paste0(
-    "
-    with sa as (
-    select st_union(geom) as geom from (
-    select service_area_60mins
-    as geom from ", pc_table, " where crscode in (",
-    paste ("'", pc_crs, "'", sep = "", collapse = ", ") ,
-    ")
-    ) as foo
-    )
-    select
-    postcode
-    from
-    data.pc_pop_2011 a, sa where st_within(a.geom, sa.geom)
-    "
-    )
+    # Get postcodes within the applicable 60 minute service area
+    query <- paste0(
+      "
+      with sa as (
+      select st_union(geom) as geom from (
+      select service_area_60mins
+      as geom from ",
+      pc_table,
+      " where crscode in (",
+      paste ("'", pc_crs, "'", sep = "", collapse = ", ") ,
+      ")
+      ) as foo
+      )
+      select
+      postcode
+      from
+      data.pc_pop_2011 a, sa where st_within(a.geom, sa.geom)
+      "
+      )
     postcodes <- sdr_dbGetQuery(con, query)
 
 
 
-  # Need to create virtual nodes for new stations.
-  # Create view of nodes table union with the new stations
-  # including all existing stations but only the postcode nodes
-  # that are needed, i.e. within the sa (so query above is used again in
-  # the where statement).
-  # First CTE (tmp) is getting virtual nodes for the proposed station(s);
-  # then select the station and relevant postcode nodes from openroads.centroidnodes;
-  # then union all select the virtual node information from tmp.
+    # Need to create virtual nodes for new stations.
+    # Create view of nodes table union with the new stations
+    # including all existing stations but only the postcode nodes
+    # that are needed, i.e. within the sa (so query above is used again in
+    # the where statement).
+    # First CTE (tmp) is getting virtual nodes for the proposed station(s);
+    # then select the station and relevant postcode nodes from openroads.centroidnodes;
+    # then union all select the virtual node information from tmp.
 
-  futile.logger::flog.info("creating virtual nodes table")
+    futile.logger::flog.info("creating virtual nodes table")
 
-  query <- paste0(
-    "create or replace view ", schema, ".centroidnodes as
-    with tmp as (
-    select
-    d.id,
-    d.crscode as reference,
-    'station' as type,
-    f.pid,
-    f.edge_id,
-    f.fraction :: double precision as frac,
-    f.closest_node as closest_real_node,
-    f.n_geom
-    from ", schema, ".proposed_stations as d,
-    lateral openroads.create_pgr_vnodes ( $$ select id, source, target, the_geom as geom from openroads.roadlinks$$, array [ d.location_geom ], 1000 ) f
-    where crscode in (",
-    paste("'", crs, "'", sep = "", collapse = ",")
-    ,
-    ")
-    ) select
-    *
-    from
-    openroads.centroidnodes where
-    type = 'station' or
-    reference in (
-    with sa as (
-    select st_union(geom) as geom from (
-    select service_area_60mins
-    as geom from ", pc_table, " where crscode in (",
-    paste ("'", pc_crs, "'", sep = "", collapse = ", ") ,
-    ")
-    ) as foo
-    )
-    select
-    postcode
-    from
-    data.pc_pop_2011 a, sa where st_within(a.geom, sa.geom)
-    )
-    UNION ALL
-    select
-    reference,
-    case
-    when pid =- 1 then
-    ( id + 40000000 ) * pid else pid
-    end as pid,
-    type,
-    edge_id,
-    frac,
-    closest_real_node,
-    n_geom
-    from
-    tmp
-    "
-    )
-  sdr_dbExecute(con, query)
+    query <- paste0(
+      "create or replace view ",
+      schema,
+      ".centroidnodes as
+      with tmp as (
+      select
+      d.id,
+      d.crscode as reference,
+      'station' as type,
+      f.pid,
+      f.edge_id,
+      f.fraction :: double precision as frac,
+      f.closest_node as closest_real_node,
+      f.n_geom
+      from ",
+      schema,
+      ".proposed_stations as d,
+      lateral openroads.create_pgr_vnodes ( $$ select id, source, target, the_geom as geom from openroads.roadlinks$$, array [ d.location_geom ], 1000 ) f
+      where crscode in (",
+      paste("'", crs, "'", sep = "", collapse = ",")
+      ,
+      ")
+      ) select
+      *
+      from
+      openroads.centroidnodes where
+      type = 'station' or
+      reference in (
+      with sa as (
+      select st_union(geom) as geom from (
+      select service_area_60mins
+      as geom from ",
+      pc_table,
+      " where crscode in (",
+      paste ("'", pc_crs, "'", sep = "", collapse = ", ") ,
+      ")
+      ) as foo
+      )
+      select
+      postcode
+      from
+      data.pc_pop_2011 a, sa where st_within(a.geom, sa.geom)
+      )
+      UNION ALL
+      select
+      reference,
+      case
+      when pid =- 1 then
+      ( id + 40000000 ) * pid else pid
+      end as pid,
+      type,
+      edge_id,
+      frac,
+      closest_real_node,
+      n_geom
+      from
+      tmp
+      "
+      )
+    sdr_dbExecute(con, query)
 
 
-  # create view of existing and proposed station(s)
+    # create view of existing and proposed station(s)
 
-  futile.logger::flog.info(paste0("creating stations view for existing stations and: ", paste0(crs, collapse = ", ")))
-
-  query <- paste0(
-    "
-    create or replace view ", schema, ".stations as
-    select crscode,
-    name,
-    location_geom,
-    service_area_1km,
-    service_area_5km,
-    service_area_10km,
-    service_area_20km,
-    service_area_30km,
-    service_area_40km,
-    service_area_60km,
-    service_area_80km,
-    service_area_105km
-    from data.stations
-    UNION ALL
-    select crscode,
-    name,
-    location_geom,
-    service_area_1km,
-    service_area_5km,
-    service_area_10km,
-    service_area_20km,
-    service_area_30km,
-    service_area_40km,
-    service_area_60km,
-    service_area_80km,
-    service_area_105km
-    from ", schema, ".proposed_stations
-    where crscode in (",
-    paste("'", crs, "'", sep = "", collapse = ", ")
-    ,
-    ")
-    "
-    )
-  sdr_dbExecute(con, query)
-
-  # generate choicesets using parallel processing
-
-  futile.logger::flog.info(paste0("starting parallel processing to generate the choicesets for ", nrow(postcodes), " postcodes"))
-
-  df <- foreach::foreach(i=postcodes$postcode, .noexport="con", .packages=c("DBI", "RPostgreSQL", "dplyr"), .combine = 'rbind') %dopar%
-  {
+    futile.logger::flog.info(paste0(
+      "creating stations view for existing stations and: ",
+      paste0(crs, collapse = ", ")
+    ))
 
     query <- paste0(
       "
-      select postcode, crscode, distance from openroads.sdr_crs_pc_nearest_stationswithpoints('",
-      schema, "', '", i,
-      "', '",
-      paste(crs, sep = "", collapse = ", "),
-      "', 1000, 0.5)
+      create or replace view ",
+      schema,
+      ".stations as
+      select crscode,
+      name,
+      location_geom,
+      service_area_1km,
+      service_area_5km,
+      service_area_10km,
+      service_area_20km,
+      service_area_30km,
+      service_area_40km,
+      service_area_60km,
+      service_area_80km,
+      service_area_105km
+      from data.stations
+      UNION ALL
+      select crscode,
+      name,
+      location_geom,
+      service_area_1km,
+      service_area_5km,
+      service_area_10km,
+      service_area_20km,
+      service_area_30km,
+      service_area_40km,
+      service_area_60km,
+      service_area_80km,
+      service_area_105km
+      from ",
+      schema,
+      ".proposed_stations
+      where crscode in (",
+      paste("'", crs, "'", sep = "", collapse = ", ")
+      ,
+      ")
       "
       )
-    nearestx <- sdr_dbGetQuery(con, query)
+    sdr_dbExecute(con, query)
 
-    if (nrow(nearestx) > 0) {
+    # generate choicesets using parallel processing
 
-      # check for nulls. If present
-      # make individual function call for each specific postcode:station pair
-      # with larger bounding box.
-      for (j in which(is.na(nearestx$distance))) {
+    futile.logger::flog.info(
+      paste0(
+        "starting parallel processing to generate the choicesets for ",
+        nrow(postcodes),
+        " postcodes"
+      )
+    )
+
+    df <-
+      foreach::foreach(
+        i = postcodes$postcode,
+        .noexport = "con",
+        .packages = c("DBI", "RPostgreSQL", "dplyr"),
+        .combine = 'rbind'
+      ) %dopar%
+      {
         query <- paste0(
           "
-          select distance from openroads.sdr_pc_station_withpoints('"
-          , schema, "', '", nearestx$postcode[j],
-          "', '", nearestx$crscode[j],
-          "', 25000, 1)
+          select postcode, crscode, distance from openroads.sdr_crs_pc_nearest_stationswithpoints('",
+          schema,
+          "', '",
+          i,
+          "', '",
+          paste(crs, sep = "", collapse = ", "),
+          "', 1000, 0.5)
           "
           )
-        d <- sdr_dbGetQuery(con, query)
-        # check if a distance is returned
-        if (nrow(d) > 0) {
-          nearestx$distance[j] <- d$distance
-        } else {
-          # if still no result then query without any bbox
-          query <- paste0(
-            "
-          select distance from openroads.sdr_pc_station_withpoints_nobbox('"
-            , schema, "', '", nearestx$postcode[j],
-            "', '", nearestx$crscode[j],
-            "')
-          "
+        nearestx <- sdr_dbGetQuery(con, query)
+
+        if (nrow(nearestx) > 0) {
+          # check for nulls. If present
+          # make individual function call for each specific postcode:station pair
+          # with larger bounding box.
+          for (j in which(is.na(nearestx$distance))) {
+            query <- paste0(
+              "
+              select distance from openroads.sdr_pc_station_withpoints('"
+              ,
+              schema,
+              "', '",
+              nearestx$postcode[j],
+              "', '",
+              nearestx$crscode[j],
+              "', 25000, 1)
+              "
+              )
+            d <- sdr_dbGetQuery(con, query)
+            # check if a distance is returned
+            if (nrow(d) > 0) {
+              nearestx$distance[j] <- d$distance
+            } else {
+              # if still no result then query without any bbox
+              query <- paste0(
+                "
+                select distance from openroads.sdr_pc_station_withpoints_nobbox('"
+                ,
+                schema,
+                "', '",
+                nearestx$postcode[j],
+                "', '",
+                nearestx$crscode[j],
+                "')
+                "
+                )
+              d <- sdr_dbGetQuery(con, query)
+              # just in case still no result trap and use -9999
+              # how to deal with this??
+              if (nrow(d) > 0) {
+                nearestx$distance[j] <- d$distance
+              } else {
+                nearestx$distance[j] <- -9999
+                futile.logger::flog.warn(
+                  "A distance could not be obtained between ",
+                  nearestx$postcode[j],
+                  " and ",
+                  nearestx$crscode[j]
+                )
+              }
+            }
+
+          } # end for each null station
+
+          choiceset <-
+            nearestx %>% dplyr::mutate("distance_rank" = dplyr::row_number(distance)) %>%
+            dplyr::filter(distance_rank <= 10) %>%
+            dplyr::arrange(distance_rank)
+
+
+        }  # end if nearestx not empty
+
+      } # end foreach postcode parallel processing
+
+
+    # remove rows (i.e. the choiceset) for any postcodes where none of the crscodes
+    # are in the choiceset
+    futile.logger::flog.info(paste0(
+      "Set of choicesets generated for: ",
+      paste0(pc_crs, collapse = ", ")
+    ))
+    futile.logger::flog.info(paste0("Rows: ", nrow(df)))
+    futile.logger::flog.info(paste0(
+      "Removing all rows for any postcode where none of: ",
+      paste0(pc_crs, collapse = ", ")
+    ))
+    df <- df %>%
+      dplyr::group_by(postcode) %>%
+      #filter(any(...)) evaluates at the group_by() level
+      dplyr::filter(any(crscode %in% pc_crs))
+    futile.logger::flog.info(paste0("Rows: ", nrow(df)))
+    futile.logger::flog.info(paste0("Unique postcodes: ", length(unique(df$postcode))))
+
+    # remove rows (i.e. the choiceset) for any postcode where one or more
+    # postcode:station distances could not be obtained - distance value will be -9999
+    # first generate warning
+    if (length(which(df$distance == -9999)) > 0) {
+      pc_missing_d <- df %>% dplyr::filter(any(distance == -9999))
+      msg <-
+        paste0(
+          length(unique(pc_missing_d$postcode)),
+          " postcode(s) removed from
+          choicesets due to missing distance: ",
+          paste0(
+            pc_missing_d$postcode[pc_missing_d$distance == -9999],
+            ":",
+            pc_missing_d$crscode[pc_missing_d$distance == -9999],
+            collapse = ", "
           )
-          d <- sdr_dbGetQuery(con, query)
-          # just in case still no result trap and use -9999
-          # how to deal with this??
-          nearestx$distance[j] <- ifelse(nrow(d) > 0, d$distance, -9999)
-        }
+        )
+      futile.logger::flog.warn(msg)
+      # now filter to remove postcodes that do not contain a -9999 distance
+      df <- df %>%
+        dplyr::filter(!any(distance == -9999))
 
-      } # end for each null station
+      futile.logger::flog.info(paste0("Rows: ", nrow(df)))
+      futile.logger::flog.info(paste0("Unique postcodes: ", length(unique(df$postcode))))
+    }
 
-      choiceset <- nearestx %>% dplyr::mutate("distance_rank" = dplyr::row_number(distance)) %>%
-        dplyr::filter(distance_rank <= 10) %>%
-        dplyr::arrange(distance_rank)
+    # log some choiceset stats
+    futile.logger::flog.info(paste0(
+      "average choiceset size: ",
+      df %>%
+        dplyr::summarise(number = n()) %>%
+        dplyr::summarise(mean(number))
+    ))
+    futile.logger::flog.info(paste0(
+      "min choiceset size: ",
+      df %>%
+        dplyr::summarise(number = n()) %>%
+        dplyr::summarise(min(number))
+    ))
+    futile.logger::flog.info(paste0(
+      "max choiceset size: ",
+      df %>%
+        dplyr::summarise(number = n()) %>%
+        dplyr::summarise(max(number))
+    ))
 
+    df <- dplyr::ungroup(df)
 
-    }  # end if nearestx not empty
+    return(df)
 
-  } # end foreach postcode parallel processing
-
-
-  # remove rows for any postcodes where none of the crscodes are in the choiceset
-
-  futile.logger::flog.info(paste0("Set of choicesets generated for: ", paste0(pc_crs, collapse = ", ")))
-  futile.logger::flog.info(paste0("Rows: ", nrow(df)))
-  futile.logger::flog.info(paste0("Removing all rows for any postcode where none of: ", paste0(pc_crs, collapse = ", ")))
-
-  df <- df %>%
-    dplyr::group_by(postcode) %>%
-    dplyr::filter(any(crscode %in% pc_crs))
-
-
-  futile.logger::flog.info(paste0("Rows: ", nrow(df)))
-  futile.logger::flog.info(paste0("Unique postcodes: ", length(unique(df$postcode))))
-
-  # log average choice set size
-  futile.logger::flog.info(paste0("average choiceset size: ",
-    df %>%
-      dplyr::summarise(number = n()) %>%
-      dplyr::summarise(mean(number))
-  ))
-
-  futile.logger::flog.info(paste0("min choiceset size: ",
-                                  df %>%
-                                    dplyr::summarise(number = n()) %>%
-                                    dplyr::summarise(min(number))
-  ))
-
-  futile.logger::flog.info(paste0("max choiceset size: ",
-                                  df %>%
-                                    dplyr::summarise(number = n()) %>%
-                                    dplyr::summarise(max(number))
-  ))
-
-  df <- dplyr::ungroup(df)
-
-  return(df)
-
-  #end function
-}
+    #end function
+    }

--- a/R/sdr_generate_probability_table.R
+++ b/R/sdr_generate_probability_table.R
@@ -58,7 +58,7 @@ sdr_generate_probability_table <- function(schema, df, tablesuffix) {
     from ", schema, ".proposed_stations
     )
     UPDATE ", schema, ".probability_",
-    tolower(tablesuffix),
+    tablesuffix,
     " as a SET
     sqr_dist = round(cast(sqrt(distance/1000) as numeric),4),
     ln_dfreq = round(cast(ln(b.frequency) as numeric),4),

--- a/R/sdr_generate_probability_table.R
+++ b/R/sdr_generate_probability_table.R
@@ -1,16 +1,16 @@
-#' Creates and populates the probability table of a station
+#' Creates and populates the probability table for a station
 #'
-#' Creates and populates the probability table of a station (isolation)
+#' Creates and populates the probability table for a station (isolation)
 #' or stations (concurrent) with the variables required to apply
-#' the station choice model. The variables are drawn from the modelschema.proposed_stations
-#' and data.stations tables.
-#' @param schema A text string for the database schema name.
+#' the station choice model. The variables are drawn from the
+#' schema.proposed_stations and data.stations tables.
+#'
+#' @param schema Character. for the database schema name.
 #' @param df A dataframe containing the choicesets.
-#' @param tablesuffix The suffix of the probability table - either crscode
-#' (isolation) or 'concurrent' (concurrent) is expected.
+#' @param tablesuffix Character, the suffix of the probability table - either
+#' crscode (isolation) or 'concurrent' (concurrent) is expected.
 #' @export
 sdr_generate_probability_table <- function(schema, df, tablesuffix) {
-
   query <- paste0(
     "create table ", schema, ".probability_",
     tablesuffix,
@@ -47,7 +47,6 @@ sdr_generate_probability_table <- function(schema, df, tablesuffix) {
   )
 
   # populate columns
-
   query <- paste0(
     "
     with tmp as (

--- a/R/tools.R
+++ b/R/tools.R
@@ -1,9 +1,11 @@
 #' Reads a SQL query from a file
 #'
 #' This function is intended to read a long and complex SQL query from a file,
-#' where it could be edited in a SQL editor, that can then be submitted as a postgreSQL query.
+#' where it could be edited in a SQL editor, that can then be submitted as a
+#' postgreSQL query.
 #'
-#' This function is based on code obtained from \url{https://stackoverflow.com/questions/44853322/how-to-read-the-contents-of-an-sql-file-into-an-r-script-to-run-a-query?noredirect=1&lq=1}.
+#' This function is based on code obtained from:
+#' \url{https://stackoverflow.com/questions/44853322/how-to-read-the-contents-of-an-sql-file-into-an-r-script-to-run-a-query?noredirect=1&lq=1}.
 #' @param filepath The filepath of the SQL file.
 #' @return A formatted sql query as a string.
 #' @importFrom magrittr %>%
@@ -11,36 +13,28 @@
 getSQL <- function(filepath){
   con = file(filepath, "r")
   sql.string <- ""
-
   while (TRUE){
     line <- readLines(con, n = 1)
-
     if ( length(line) == 0 ){
       break
     }
-
     line <- gsub("\\t", " ", line)
-
     if(grepl("--",line) == TRUE){
       line <- paste(sub("--","/*",line),"*/")
     }
-
     sql.string <- paste(sql.string, line)
   }
-
   close(con)
   return(sql.string)
 }
 
-
-#' Formats an RPostgreSQL getQuery and then submits the query
-#'
+#' Formats an RPostgres getQuery and then submits the query
 #'
 #' This function allows the text of a SQL query to be formatted across multiple
 #' lines in an R document, by stripping the line breaks prior to submitting the
 #' query based on provided \code{con} object.
 #'
-#' @param con A database connection object for RPostgreSQL.
+#' @param con A database connection object for RPostgres.
 #' @param query The query to be formatted.
 #' @export
 sdr_dbGetQuery <- function(con, query) {
@@ -48,24 +42,18 @@ sdr_dbGetQuery <- function(con, query) {
   RPostgres::dbGetQuery(con, query)
 }
 
-
-#' Formats an RPostgreSQL dbExecute and then submits the query
-#'
+#' Formats an RPostgres dbExecute and then submits the query
 #'
 #' This function allows the text of a SQL query to be formatted across multiple
 #' lines in an R document, by stripping the line breaks prior to submitting the
-#' query based on provided \code{con} object.
+#' query based on provided \code{con} object. Also logs the queries if in debug
+#' mode.
 #'
-#' @param con A database connection object for RPostgreSQL.
+#' @param con A database connection object for RPostgres.
 #' @param query The query to be formatted.
 #' @export
-  sdr_dbExecute <- function(con, query) {
+sdr_dbExecute <- function(con, query) {
   query <- gsub("\\s+", " ", stringr::str_trim(query))
   result <- RPostgres::dbExecute(con, query)
   futile.logger::flog.debug(paste0(query, ": rows affected: ", result))
 }
-
-
-
-
-

--- a/inst/.gitignore
+++ b/inst/.gitignore
@@ -1,0 +1,1 @@
+manual_test

--- a/inst/r-scripts/.gitignore
+++ b/inst/r-scripts/.gitignore
@@ -1,0 +1,1 @@
+testing.R

--- a/inst/r-scripts/create_virtual_nodes_table_pc_centroids.R
+++ b/inst/r-scripts/create_virtual_nodes_table_pc_centroids.R
@@ -1,8 +1,5 @@
-
-
 # create virtual nodes table for use in pgRouting functions
-# using postcode centroids (from AOI) and all railway stations
-# including proposed station to be modelled <- not implemented yet
+# using postcode centroids and railway stations.
 
 # need to check  if any nulls are returned?
 # depends on the search tolerance. Currently set at 1km, can probably

--- a/inst/r-scripts/main.R
+++ b/inst/r-scripts/main.R
@@ -225,8 +225,8 @@ if (length(idx > 0)) {
   ))
 }
 
-# check id is unique
-if (anyDuplicated(stations$id) > 0) {
+# check crscode is unique
+if (anyDuplicated(stations$crscode) > 0) {
   preflight_failed <- TRUE
   flog.error("station id must be unique")
 }
@@ -242,18 +242,20 @@ if (isFALSE(all(abs_check))) {
   flog.error("abstraction stations are not provided in the correct format")
 }
 
-# check that abstraction stations are valid crscodes
-abs_crs <- unique(na.omit(unlist(strsplit(
-  stations$abstract, ","
-))))
-# get the index for those not valid
-idx <- which(!(abs_crs %in% crscodes$crscode))
-if (length(idx > 0)) {
-  preflight_failed <- TRUE
-  flog.error(paste(
-    "The following abstraction group crscodes are not valid: ",
-    paste(abs_crs[idx], collapse = ", ")
-  ))
+# check that abstraction stations (if there are any) are valid crscodes
+if (length(unique(na.omit(stations$abstract))) > 0) {
+  abs_crs <- unique(na.omit(unlist(strsplit(
+    stations$abstract, ","
+  ))))
+  # get the index for those not valid
+  idx <- which(!(abs_crs %in% crscodes$crscode))
+  if (length(idx > 0)) {
+    preflight_failed <- TRUE
+    flog.error(paste(
+      "The following abstraction group crscodes are not valid: ",
+      paste(abs_crs[idx], collapse = ", ")
+    ))
+  }
 }
 
 # check that frequency and number of parking spaces are integer > 0
@@ -390,7 +392,6 @@ if (isFALSE(all(sapply(stations$acc_north, function(x)
   flog.error("access northings must all be 6 character strings containing 0-9 only")
 }
 
-
 # check if access coordinates fall within GB extent
 check_coords <- function(coords) {
   query <- paste0(
@@ -413,7 +414,6 @@ if (length(idx) > 0) {
     paste0(stations$crscode[idx], ": ", stations$location[idx], collapse = ", ")
   ))
 }
-
 
 # stop if any of the pre-flight checks have failed
 if (isTRUE(preflight_failed)) {

--- a/inst/r-scripts/main.R
+++ b/inst/r-scripts/main.R
@@ -42,7 +42,7 @@ options(
 
 # During testing set this variable to TRUE. This produces fake 60-minute
 # proposed station service areas which are actually only 5-minute service areas.
-testing <- FALSE
+testing <- TRUE
 flog.info(paste0("Testing mode: ", ifelse(isTRUE(testing), "ON", "OFF")))
 
 # Set up a database connection.

--- a/inst/r-scripts/main.R
+++ b/inst/r-scripts/main.R
@@ -3,6 +3,7 @@
 library(stationdemandr)
 library(dplyr)
 library(tidyr)
+library(readr)
 library(foreach)
 library(stringr)
 library(doParallel)
@@ -763,6 +764,10 @@ for (i in c(1, 60)) {
   sdr_dbExecute(con, query)
 }
 
+# read sa.log into sdr.log - from workaround in foreach using sink() in
+# sdr_create_service_areas
+
+cat(read_lines(file = "sa.log"), file = "sdr.log", append = TRUE, fill = TRUE)
 
 flog.info("station service area generation completed")
 

--- a/inst/r-scripts/main.R
+++ b/inst/r-scripts/main.R
@@ -18,6 +18,10 @@ if (file.exists("sdr.log")) {
   file.remove("sdr.log")
 }
 
+if (file.exists("sa.log")) {
+  file.remove("sa.log")
+}
+
 # set up logging
 flog.appender(appender.file("sdr.log"))
 # set logging level

--- a/inst/r-scripts/main.R
+++ b/inst/r-scripts/main.R
@@ -46,7 +46,7 @@ options(
 
 # During testing set this variable to TRUE. This produces fake 60-minute
 # proposed station service areas which are actually only 5-minute service areas.
-testing <- TRUE
+testing <- FALSE
 flog.info(paste0("Testing mode: ", ifelse(isTRUE(testing), "ON", "OFF")))
 
 # Set up a database connection.
@@ -1007,41 +1007,33 @@ query <- paste0(
 )
 sdr_dbExecute(con, query)
 
-
-# Call:
-#   lm(formula = log(entex1112) ~ log(te19cmb_15212) + log(dailyfrequency_2013_all) +
-#        log1p(work_pop_1m) + log1p(carspaces) + electric_dummy +
-#        tcard_bound_dummy + TerminusDummy, data = catef_te_models_ews)
-#
-# Residuals:
-#   Min      1Q  Median      3Q     Max
-# -2.9479 -0.4128  0.0056  0.4287  3.3785
-#
+# version with altered application of decay function
 # Coefficients:
 #   Estimate Std. Error t value Pr(>|t|)
-# (Intercept)                  3.672122   0.095382  38.499  < 2e-16 ***
-#   log(te19cmb_15212)           0.366469   0.018194  20.142  < 2e-16 ***
-#   log(dailyfrequency_2013_all) 1.139167   0.027473  41.465  < 2e-16 ***
-#   log1p(work_pop_1m)           0.053005   0.006840   7.749 1.54e-14 ***
-#   log1p(carspaces)             0.129301   0.009147  14.136  < 2e-16 ***
-#   electric_dummy               0.243414   0.041037   5.932 3.59e-09 ***
-#   tcard_bound_dummy            0.299968   0.091295   3.286  0.00104 **
-#   TerminusDummy                0.781959   0.083414   9.374  < 2e-16 ***
+# (Intercept)                  3.601572   0.097337  37.001  < 2e-16 ***
+#   log(te19cmb_15212_adj)       0.362379   0.017917  20.225  < 2e-16 ***
+#   log(dailyfrequency_2013_all) 1.138605   0.027443  41.490  < 2e-16 ***
+#   log1p(work_pop_1m)           0.052576   0.006840   7.687 2.48e-14 ***
+#   log1p(carspaces)             0.126604   0.009169  13.808  < 2e-16 ***
+#   electric_dummy               0.243148   0.040996   5.931 3.61e-09 ***
+#   tcard_bound_dummy            0.294408   0.091232   3.227  0.00127 **
+#   TerminusDummy                0.777482   0.083368   9.326  < 2e-16 ***
 #   ---
 #   Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
 #
-# Residual standard error: 0.6909 on 1784 degrees of freedom
-# Multiple R-squared:  0.8506,	Adjusted R-squared:   0.85
-# F-statistic:  1451 on 7 and 1784 DF,  p-value: < 2.2e-16
+# Residual standard error: 0.6904 on 1784 degrees of freedom
+# Multiple R-squared:  0.8508,	Adjusted R-squared:  0.8502
+# F-statistic:  1454 on 7 and 1784 DF,  p-value: < 2.2e-16
+#
 
-var_intercept <- 3.672122
-var_population <- 0.366469
-var_frequency <- 1.139167
-var_workpop <- 0.053005
-var_carspaces <- 0.129301
-var_electric <- 0.243414
-var_tcardbound <- 0.299968
-var_terminus <- 0.781959
+var_intercept <- 3.601572
+var_population <- 0.362379
+var_frequency <- 1.138605
+var_workpop <- 0.052576
+var_carspaces <- 0.126604
+var_electric <- 0.243148
+var_tcardbound <- 0.294408
+var_terminus <- 0.777482
 
 # base forecast
 

--- a/inst/sql/create_virtual_nodes_openroads.sql
+++ b/inst/sql/create_virtual_nodes_openroads.sql
@@ -1,4 +1,5 @@
--- enhanced from: https://gis.stackexchange.com/questions/88196/how-can-i-transform-polylines-into-points-every-n-metres-in-postgis
+-- enhanced from:
+-- https://gis.stackexchange.com/questions/88196/how-can-i-transform-polylines-into-points-every-n-metres-in-postgis
 -- creates a table of virtual nodes for roadlinks
 -- node pid created as negative integer
 -- requires sequence called vnodes_pid_seq starting at 10000000
@@ -20,7 +21,8 @@ geometries as (
     select
         i, linem, edge_id,
         (st_dump(st_geometryn(st_locatealong(linem, i), 1))).geom as geom
-        -- note the .geom construct because st_dump returns a geom component and an array of integers (path).
+        -- note the .geom construct because st_dump returns a geom component and
+        -- an array of integers (path).
     from linemeasure),
 points as (
     select
@@ -28,6 +30,7 @@ points as (
         st_setsrid(st_makepoint(st_x(geom), st_y(geom)), 27700) as geom
 from geometries),
 fractions as (
-select -pid as pid, edge_id, geom as the_geom, st_linelocatepoint(linem, geom) as fraction from points order by pid asc)
+select -pid as pid, edge_id, geom as the_geom, st_linelocatepoint(linem, geom)
+as fraction from points order by pid asc)
 -- only want nodes that are not existing source or target nodes
 select * from fractions where fraction > 0 and fraction < 1

--- a/inst/sql/function_create_pgr_vnodes.sql
+++ b/inst/sql/function_create_pgr_vnodes.sql
@@ -1,9 +1,9 @@
--- Adapted from code block 11.2 from "pgROUTING - a practical guide".
--- Amended to return the geom of the virtual nodes (needed for enhanced bbox functions),
--- or otherwise the geom of a real node if fraction <0.01 (edge start) or >0.99 (edge end)
--- Returns virtual node pids and fraction, or if virtual node is at the same location as a source
--- or target real node (i.e either end of an edge) the source or target node pid
--- is returned (otherwise routing would not work).
+-- Adapted from code block 11.2 from "pgROUTING - a practical guide". Amended to
+-- return the geom of the virtual nodes (needed for enhanced bbox functions), or
+-- otherwise the geom of a real node if fraction <0.01 (edge start) or >0.99
+-- (edge end) Returns virtual node pids and fraction, or if virtual node is at
+-- the same location as a source or target real node (i.e either end of an edge)
+-- the source or target node pid is returned (otherwise routing would not work).
 create or replace function
     openroads.create_pgr_vnodes(network_sql text,
     points geometry[], tolerance float default 0.01)

--- a/inst/sql/function_sdr_crs_pc_nearest_stationswithpoints.sql
+++ b/inst/sql/function_sdr_crs_pc_nearest_stationswithpoints.sql
@@ -3,9 +3,13 @@
 -- function checks if nearest x stations contain the crscode(s) provided in the paramter
 -- if not then don't bother looking up any distance and return null table.
 
-CREATE OR REPLACE FUNCTION "openroads"."sdr_crs_pc_nearest_stationswithpoints"("schema" text, "pc" text, "crs" text, "expand_min" int8=0, "expand_pc" float4=0.5)
-  RETURNS TABLE("postcode" text, "station" text, "crscode" text, "distance" float8) AS $BODY$
-  declare
+create or replace function
+"openroads"."sdr_crs_pc_nearest_stationswithpoints"("schema" text, "pc" text,
+"crs" text, "expand_min" int8=0, "expand_pc" float4=0.5)
+returns table("postcode" text, "station" text, "crscode" text, "distance"
+float8) as $body$
+
+declare
 sa character varying;
 node_sql character varying;
 origin_geom geometry;
@@ -17,7 +21,9 @@ begin
 
 select geom from data.pc_pop_2011 a where a.postcode = pc into origin_geom;
 
-execute format ('select pid from %1$s.centroidnodes a where a.reference = $1', schema ) using pc into origin_node;
+execute
+  format ('select pid from %1$s.centroidnodes a where a.reference = $1', schema )
+  using pc into origin_node;
 
 execute format ('
 select
@@ -43,34 +49,40 @@ select
 
 -- define virtual node sql, restrict to station vnodes (type = station) or the origin pid and only ever pids < 0)
 -- have to separate this out to inject the origin node.
-node_sql := format ( 'select pid*-1 as pid, edge_id, frac::double precision as fraction from %1$s.centroidnodes where (type = $type$station$type$ or pid = %2$s) and pid <0', schema, origin_node );
+node_sql := format ( 'select pid*-1 as pid, edge_id, frac::double precision as
+fraction from %1$s.centroidnodes where (type = $type$station$type$ or pid =
+%2$s) and pid <0', schema, origin_node );
 
-execute format ('create temp table tmp as (select $1 as postcode, d.name, d.crscode, d.%2$s, d.location_geom, e.pid from %1$s.stations d
-                                           left join %1$s.centroidnodes e on d.crscode = e.reference
-                                           where st_within($2, %2$s))', schema, sa) using pc, origin_geom;
+execute format ('create temp table tmp as (select $1 as postcode, d.name,
+d.crscode, d.%2$s, d.location_geom, e.pid from %1$s.stations d left join
+%1$s.centroidnodes e on d.crscode = e.reference where st_within($2, %2$s))',
+schema, sa) using pc, origin_geom;
 
--- check if any of the station(s) crscodse are present in tmp. if not we don't
+-- check if any of the station(s) crscodes are present in tmp. if not we don't
 -- need to bother looking up distances, and a null table is returned.
 -- convert crs to array (can be multiple stations for concurrent state in form
 -- "FEN, HON, AXM"
 if string_to_array(crs, ', ') && array(select t.crscode from tmp t)
 then
-return query execute format ( '
-                              select postcode, name, crscode, r.agg_cost as distance from tmp as d
-                              /* lateral runs the pgr function for each row of d */
-                              /* left join lateral ensures nulls are returned - these need bigger bbox */
-                              left join lateral openroads.bbox_pgr_withpointscost(
-                              $edges$select id, source, target, cost_len as cost, the_geom
-                              from openroads.roadlinks$edges$,
-                              $2,
-                              $3,
-                              d.pid,
-                              false,
-                              $1,
-                              d.location_geom,
-                              expand_min := $4,
-                              expand_pc := $5) r on true
-                              order by distance asc', sa) using
+return
+  query
+    execute
+      format ( '
+        select postcode, name, crscode, r.agg_cost as distance from tmp as d
+        /* lateral runs the pgr function for each row of d */
+        /* left join lateral ensures nulls are returned - these need bigger bbox */
+        left join lateral openroads.bbox_pgr_withpointscost(
+          $edges$select id, source, target, cost_len as cost, the_geom
+          from openroads.roadlinks$edges$,
+          $2,
+          $3,
+          d.pid,
+          false,
+          $1,
+          d.location_geom,
+          expand_min := $4,
+          expand_pc := $5) r on true
+          order by distance asc', sa) using
 origin_geom,
 node_sql,
 origin_node,

--- a/inst/sql/function_sdr_pc_station_withpoints.sql
+++ b/inst/sql/function_sdr_pc_station_withpoints.sql
@@ -3,8 +3,9 @@
 -- intended to be used to widen the bbox for stations where distance
 -- returned null when looking for the nearest 10 stations
 
-CREATE OR REPLACE FUNCTION "openroads"."sdr_pc_station_withpoints"("schema" text, "pc" text, "crs" text, "expand_min" int8=0, "expand_pc" float4=0.5)
-  RETURNS TABLE("distance" float8) AS $BODY$
+create or replace function "openroads"."sdr_pc_station_withpoints"("schema"
+text, "pc" text, "crs" text, "expand_min" int8=0, "expand_pc" float4=0.5)
+  returns table("distance" float8) as $body$
 declare
 sa character varying;
 node_sql character varying;
@@ -18,14 +19,24 @@ begin
 
 select geom from data.pc_pop_2011 a where a.postcode = pc into origin_geom;
 
-execute format (' select location_geom from %1$s.stations a where a.crscode = $1 ', schema) using crs into station_geom;
+execute
+  format (' select location_geom from %1$s.stations a where a.crscode = $1 ', schema)
+  using
+   crs into station_geom;
 
-execute format (' select pid from %1$s.centroidnodes a where a.reference = $1 ', schema) using pc into origin_node;
+execute
+  format (' select pid from %1$s.centroidnodes a where a.reference = $1 ', schema)
+  using
+   pc into origin_node;
 
-execute format (' select pid from %1$s.centroidnodes a where a.reference = $1 ', schema) using crs into station_node;
+execute format (' select pid from %1$s.centroidnodes a where a.reference = $1 ', schema)
+  using
+    crs into station_node;
 
 -- do node sql separately
-node_sql := format ( 'select pid*-1 as pid, edge_id, frac::double precision as fraction from %1$s.centroidnodes where (pid = %2$s or pid = %3$s) and pid <0', schema, station_node, origin_node);
+node_sql := format ( 'select pid*-1 as pid, edge_id, frac::double precision as
+fraction from %1$s.centroidnodes where (pid = %2$s or pid = %3$s) and pid <0',
+schema, station_node, origin_node);
 return query execute format ( '
 			select d.agg_cost from openroads.bbox_pgr_withpointscost(
 			$edges$select id, source, target, cost_len as cost, the_geom

--- a/inst/sql/function_sdr_pc_station_withpoints_nobbox.sql
+++ b/inst/sql/function_sdr_pc_station_withpoints_nobbox.sql
@@ -5,8 +5,11 @@
 -- last resort as uses no bounding box at all, so slow
 
 
-CREATE OR REPLACE FUNCTION "openroads"."sdr_pc_station_withpoints_nobbox"("schema" text, "pc" text, "crs" text)
-  RETURNS TABLE("distance" float8) AS $BODY$
+create or replace function
+"openroads"."sdr_pc_station_withpoints_nobbox"("schema" text, "pc" text, "crs"
+text)
+
+returns table("distance" float8) as $body$
 declare
 sa character varying;
 node_sql character varying;
@@ -20,14 +23,19 @@ begin
 
 select geom from data.pc_pop_2011 a where a.postcode = pc into origin_geom;
 
-execute format (' select location_geom from %1$s.stations a where a.crscode = $1 ', schema) using crs into station_geom;
+execute format (' select location_geom from %1$s.stations a where a.crscode = $1
+', schema) using crs into station_geom;
 
-execute format (' select pid from %1$s.centroidnodes a where a.reference = $1 ', schema) using pc into origin_node;
+execute format (' select pid from %1$s.centroidnodes a where a.reference = $1 ',
+schema) using pc into origin_node;
 
-execute format (' select pid from %1$s.centroidnodes a where a.reference = $1 ', schema) using crs into station_node;
+execute format (' select pid from %1$s.centroidnodes a where a.reference = $1 ',
+schema) using crs into station_node;
 
 -- do node sql separately
-node_sql := format ( 'select pid*-1 as pid, edge_id, frac::double precision as fraction from %1$s.centroidnodes where (pid = %2$s or pid = %3$s) and pid <0', schema, station_node, origin_node);
+node_sql := format ( 'select pid*-1 as pid, edge_id, frac::double precision as
+fraction from %1$s.centroidnodes where (pid = %2$s or pid = %3$s) and pid <0',
+schema, station_node, origin_node);
 return query execute format ( '
 			select d.agg_cost from pgr_withpointscost(
 			$edges$select id, source, target, cost_len as cost, the_geom

--- a/man/getSQL.Rd
+++ b/man/getSQL.Rd
@@ -14,8 +14,10 @@ A formatted sql query as a string.
 }
 \description{
 This function is intended to read a long and complex SQL query from a file,
-where it could be edited in a SQL editor, that can then be submitted as a postgreSQL query.
+where it could be edited in a SQL editor, that can then be submitted as a
+postgreSQL query.
 }
 \details{
-This function is based on code obtained from \url{https://stackoverflow.com/questions/44853322/how-to-read-the-contents-of-an-sql-file-into-an-r-script-to-run-a-query?noredirect=1&lq=1}.
+This function is based on code obtained from:
+\url{https://stackoverflow.com/questions/44853322/how-to-read-the-contents-of-an-sql-file-into-an-r-script-to-run-a-query?noredirect=1&lq=1}.
 }

--- a/man/sdr_calculate_probabilities.Rd
+++ b/man/sdr_calculate_probabilities.Rd
@@ -2,18 +2,19 @@
 % Please edit documentation in R/sdr_calculate_probabilities.R
 \name{sdr_calculate_probabilities}
 \alias{sdr_calculate_probabilities}
-\title{Calculates probabilities for postcode choicesets}
+\title{Calculates the probabilities for postcode choicesets}
 \usage{
 sdr_calculate_probabilities(schema, tablesuffix)
 }
 \arguments{
-\item{schema}{A text string for the database schema name.}
+\item{schema}{Character, the database schema name.}
 
-\item{tablesuffix}{The suffix of the probability table - either crscode
-(isolation) or 'concurrent' (concurrent) is expected.}
+\item{tablesuffix}{Character, the suffix of the probability table - either
+crscode (isolation) or 'concurrent' (concurrent) is expected.}
 }
 \description{
-Calculates the probability of each station being chosen within the postcode choicesets
-contained in the specified probability table for the proposed station (isolation)
-or stations (concurrent). The required columns are created in the table.
+Calculates the probability of each station being chosen within the postcode
+choicesets contained in the specified probability table for the proposed
+station (isolation) or stations (concurrent). The required columns are
+created in the table.
 }

--- a/man/sdr_calculate_prweighted_population.Rd
+++ b/man/sdr_calculate_prweighted_population.Rd
@@ -7,41 +7,43 @@
 sdr_calculate_prweighted_population(schema, crs, tablesuffix)
 }
 \arguments{
-\item{schema}{A text string for the database schema name.}
+\item{schema}{Character, the database schema name.}
 
-\item{crs}{The crscode of the station.}
+\item{crs}{Character, the crscode of the station.}
 
-\item{tablesuffix}{The suffix of the probability table - either crscode
-(isolation) or 'concurrent' (concurrent) is expected.}
+\item{tablesuffix}{Character, the suffix of the probability table - either
+crscode (isolation) or 'concurrent' (concurrent) is expected.}
 }
 \description{
 Calculates the total probability weighted population for a station
 by weighting the population of each postcode by the choice
 probability for the station and a distance decay function and then summing
-across all postcodes. In addition takes account of population data in the
+across all postcodes. In addition, takes account of population data in the
 exogenous inputs table.
 }
 \details{
 The calculation is different depending on whether the concurrent or isolation
-method is to be used. For concurrent treatment there is only a single probability
-table and a spatial query is used so that only those postcodes within the 60 minutes
-service area of an individual proposed station are included. This is because a single merged
-service area (within 60 minutes of all the stations) was used to generate the postcodes
-in the probability table. But only those within 60 minutes of each proposed station
-should be considered when generating the weighted population. It is also necessary
-to only include the exogenous population for postcodes that fall within a
-station's 60-minute service area.
+method is to be used. For concurrent treatment there is only a single
+probability table and a spatial query is used so that only those postcodes
+within the 60 minute service area of an individual proposed station are
+included. This is because a single merged service area (within 60 minutes of
+all the stations) was used to generate the postcodes in the probability table.
+But only those within 60 minutes of each proposed station should be considered
+when generating the weighted population. It is also necessary to only include
+the exogenous population for postcodes that fall within a station's 60-minute
+service area.
 
-There are 3 CTE queries involved. The first (nw_pop) is population weighted just
-by probability when the distance to a station is <= 750m. The second (w_pop) is population
-weighted by probability AND by distance decay function. The third (adj_pop) gets
-the probability weighted population based on the exogenous data table, applying
-the decay function for access distances > 750m.
+There are thre CTE queries involved. The first (nw_pop) is population weighted
+just by probability when the distance to a station is <= 750m. The second (w_pop)
+is population weighted by probability AND by distance decay function. The third
+(adj_pop) gets the probability weighted population based on the exogenous data
+table, applying the decay function for access distances > 750m.
 
-For stations treated in isolation the FROM table for nw_pop and w_pop is the probability table for that
-station and census postcode population is joined by a left join, so only relevant
-postcodes will ever be included. In the case of adj_pop the from table is the exogenous table
-and the probability is left joined from the probability table. This will be null if the postcode
-is not present in the probability table and it will not in those circumstances contribute to the sum.
-As in SQL NULL times anything is NULL.
+For stations treated in isolation the FROM table for nw_pop and w_pop is the
+probability table for that station and census postcode population is joined
+by a left join, so only relevant postcodes will ever be included. In the case
+of adj_pop the from table is the exogenous table and the probability is left
+joined from the probability table. This will be null if the postcode is not
+present in the probability table and it will not in those circumstances
+contribute to the sum - as in SQL, NULL times anything is NULL.
 }

--- a/man/sdr_create_json_catchment.Rd
+++ b/man/sdr_create_json_catchment.Rd
@@ -8,41 +8,50 @@ sdr_create_json_catchment(schema, type, crs, tablesuffix, abs_crs = NULL,
   cutoff = 0.01, tolerance = 0.1)
 }
 \arguments{
-\item{schema}{A text string for the database schema name.}
+\item{schema}{Character, the database schema name.}
 
-\item{type}{Character. Must be either "proposed" or "abstraction". Indicates whether this catchment is required for a proposed station
-or as part of an abstraction analysis. See details.}
+\item{type}{Character, must be either "proposed" or "abstraction". Indicates
+whether this catchment is required for a proposed station or as part of an
+abstraction analysis. See details.}
 
-\item{crs}{Character. The crscode of the station the catchment is for.}
+\item{crs}{Character, the crscode of the station the catchment is for.}
 
-\item{tablesuffix}{Character. Suffix of the probability table (i.e. the part after "schema.probability_")}
+\item{tablesuffix}{Character, suffix of the probability table (i.e. the part
+after "schema.probability_")}
 
-\item{abs_crs}{Character. The crscode of a proposed station (or "concurrent" if
-using concurrent mode). Only relevant if \code{type} is set to "abstraction". When specified an
-\emph{after} catchment is generated for station \code{crs} with station \code{abs_crs} present.}
+\item{abs_crs}{Character, the crscode of a proposed station (or "concurrent"
+if using concurrent mode). Only relevant if \code{type} is set to
+"abstraction". When specified an \emph{after} catchment is generated for
+station \code{crs} with station \code{abs_crs} present.}
 
-\item{cutoff}{Numeric. Defines the threshold probability below which to exclude a postcode from
-the catchment. Default is 0.01 (i.e. any postcodes with a probability of \eqn{>= 0.01}
-for the station defined in \code{crs} will be included in the catchment).}
+\item{cutoff}{Numeric, defines the threshold probability below which to
+exclude a postcode from the catchment. Default is 0.01 (i.e. any postcodes
+with a probability of \eqn{>= 0.01} for the station defined in \code{crs}
+will be included in the catchment).}
 
-\item{tolerance}{numeric. Tolerance for ST_SimplifyPreserveTopology. Default 0.1.}
+\item{tolerance}{Numeric, tolerance for ST_SimplifyPreserveTopology. Default
+is 0.1.}
 }
 \description{
 Creates a GeoJSON probabilistic catchment for a station. Includes a spatial
-query to check that any candidate postcodes are within the 60 minute service area of the
-station (only important for \emph{concurrent} mode as for \emph{isolation} mode only those postcodes
-within 60 minutes of a station will be in that station's probability table).
+query to check that any candidate postcodes are within the 60 minute service
+area of the station (only important for \emph{concurrent} mode as for
+\emph{isolation} mode only those postcodes within 60 minutes of a station
+will be in that station's probability table).
 }
 \details{
-If \code{type} is set to "proposed" then the station defined by \code{crs} is assumed to be
-a proposed station present in the modelschema.proposed_stations table. The 60-minute service area
-for the station is expected to be in this table and the GeoJSON catchment is written to this table.
+If \code{type} is set to "proposed" then the station defined by \code{crs}
+is assumed to be a proposed station present in the schema.proposed_stations
+table. The 60-minute service area for the station is expected to be in this
+table and the GeoJSON catchment is also written to this table.
 
-If \code{type} is "abstraction" then the station defined by \code{crs} is assumed to be
-an at-risk station that is part of an abstraction analysis. The 60-minute service area for the
-station is assumed to be located in the data.stations table and the catchment is written to the
-modelschema.abstraction_results table. If \code{abs_crs} is not specified then a \emph{before} catchment
-is generated for station \code{crs}. If a proposed station is provided in \code{abs_crs} (or this
-is given the value "concurrent" in the case of concurent mode) then an \emph{after} catchment is generated,
+If \code{type} is "abstraction" then the station defined by \code{crs} is
+assumed to be an at-risk station that is part of an abstraction analysis. The
+60-minute service area for the station is assumed to be located in the
+data.stations table and the catchment is written to the
+schema.abstraction_results table. If \code{abs_crs} is not specified then a
+\emph{before} catchment is generated for station \code{crs}. If a proposed
+station is provided in \code{abs_crs} (or this is given the value "concurrent"
+in the case of concurent mode) then an \emph{after} catchment is generated,
 reflecting the situation after \code{abs_crs}.
 }

--- a/man/sdr_create_service_areas.Rd
+++ b/man/sdr_create_service_areas.Rd
@@ -8,29 +8,29 @@ sdr_create_service_areas(schema, df, identifier, sa, table, cost = "len",
   target = 0.9)
 }
 \arguments{
-\item{schema}{A text string for the database schema name.}
+\item{schema}{Character, the database schema name.}
 
-\item{df}{A dataframe with a column named "location"
+\item{df}{A data frame with a column named "location"
 which has the easting and northing of the station location.}
 
-\item{identifier}{A text string which uniquely identifies
-a station in both the provided dataframe \emph{and} in the target \code{table}.}
+\item{identifier}{Character, uniquely identifies a station in both the
+provided data frame \emph{and} in the target \code{table}.}
 
-\item{sa}{A vector of integer values for the required service areas. Should
-be in metres when cost is distance and minutes when cost is time.}
+\item{sa}{Numeric vector of integer values for the required service areas.
+Should be in metres when cost is distance and minutes when cost is time.}
 
-\item{table}{A text string for the target database table name.}
+\item{table}{Character, the target database table name.}
 
-\item{cost}{A text string, either "len" for a distance-based service area or
+\item{cost}{Character, either "len" for a distance-based service area or
 "time" for a time-based service area. Default is "len".}
 
-\item{target}{The target percent of area of convex hull that ST_ConvexHull
-will try to approach before giving up or exiting. Default is 0.9.}
+\item{target}{Numeric, the target percent of area of convex hull that
+ST_ConvexHull will try to approach before giving up or exiting. Default is 0.9.}
 }
 \description{
 Creates a distance or time based network service area around stations in
-the provided data frame using the pgRouting function \code{pgr_withpointsdd}. The
-service area geometry is written to the specified database \code{table} in the
-specified database \code{schema}.The supplied \code{identifier} links the stations
-in the data frame and the database table.
+the provided data frame using the pgRouting function \code{pgr_withpointsdd}.
+The service area geometry is written to the specified database \code{table}
+in the specified database \code{schema}. The supplied \code{identifier} links
+the stations in the data frame and the database table. Uses parallel processing.
 }

--- a/man/sdr_create_service_areas.Rd
+++ b/man/sdr_create_service_areas.Rd
@@ -4,19 +4,22 @@
 \alias{sdr_create_service_areas}
 \title{Creates a distance or time based network service area around stations}
 \usage{
-sdr_create_service_areas(schema, df, sa, table, cost = "len",
+sdr_create_service_areas(schema, df, identifier, sa, table, cost = "len",
   target = 0.9)
 }
 \arguments{
 \item{schema}{A text string for the database schema name.}
 
-\item{df}{A dataframe with a column called "location" which has easting and
-northing of the station location.}
+\item{df}{A dataframe with a column named "location"
+which has the easting and northing of the station location.}
+
+\item{identifier}{A text string which uniquely identifies
+a station in both the provided dataframe \emph{and} in the target \code{table}.}
 
 \item{sa}{A vector of integer values for the required service areas. Should
 be in metres when cost is distance and minutes when cost is time.}
 
-\item{table}{A text string for the database table name.}
+\item{table}{A text string for the target database table name.}
 
 \item{cost}{A text string, either "len" for a distance-based service area or
 "time" for a time-based service area. Default is "len".}
@@ -27,6 +30,7 @@ will try to approach before giving up or exiting. Default is 0.9.}
 \description{
 Creates a distance or time based network service area around stations in
 the provided data frame using the pgRouting function \code{pgr_withpointsdd}. The
-service area geometry is written to the specified database table in the
-specified database schema.
+service area geometry is written to the specified database \code{table} in the
+specified database \code{schema}.The supplied \code{identifier} links the stations
+in the data frame and the database table.
 }

--- a/man/sdr_dbExecute.Rd
+++ b/man/sdr_dbExecute.Rd
@@ -2,17 +2,18 @@
 % Please edit documentation in R/tools.R
 \name{sdr_dbExecute}
 \alias{sdr_dbExecute}
-\title{Formats an RPostgreSQL dbExecute and then submits the query}
+\title{Formats an RPostgres dbExecute and then submits the query}
 \usage{
 sdr_dbExecute(con, query)
 }
 \arguments{
-\item{con}{A database connection object for RPostgreSQL.}
+\item{con}{A database connection object for RPostgres.}
 
 \item{query}{The query to be formatted.}
 }
 \description{
 This function allows the text of a SQL query to be formatted across multiple
 lines in an R document, by stripping the line breaks prior to submitting the
-query based on provided \code{con} object.
+query based on provided \code{con} object. Also logs the queries if in debug
+mode.
 }

--- a/man/sdr_dbGetQuery.Rd
+++ b/man/sdr_dbGetQuery.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/tools.R
 \name{sdr_dbGetQuery}
 \alias{sdr_dbGetQuery}
-\title{Formats an RPostgreSQL getQuery and then submits the query}
+\title{Formats an RPostgres getQuery and then submits the query}
 \usage{
 sdr_dbGetQuery(con, query)
 }
 \arguments{
-\item{con}{A database connection object for RPostgreSQL.}
+\item{con}{A database connection object for RPostgres.}
 
 \item{query}{The query to be formatted.}
 }

--- a/man/sdr_frequency_group_adjustment.Rd
+++ b/man/sdr_frequency_group_adjustment.Rd
@@ -7,14 +7,14 @@
 sdr_frequency_group_adjustment(schema, df, tablesuffix)
 }
 \arguments{
-\item{schema}{A text string for the database schema name.}
+\item{schema}{Character, the database schema name.}
 
 \item{df}{A data frame containing the frequency group input. In isolation mode
 this will relate to a specific station. In concurrent mode there will only be
 a single frequency group across all stations.}
 
-\item{tablesuffix}{The suffix of the probability table to be updated - either a crscode
-(isolation) or 'concurrent' (concurrent) is expected.}
+\item{tablesuffix}{Character, the suffix of the probability table to be
+updated - either a crscode (isolation) or 'concurrent' (concurrent) is expected.}
 }
 \description{
 Updates the probability table for a station (isolation) or

--- a/man/sdr_generate_choicesets.Rd
+++ b/man/sdr_generate_choicesets.Rd
@@ -7,65 +7,68 @@
 sdr_generate_choicesets(schema, crs, existing = FALSE, abs_crs = NULL)
 }
 \arguments{
-\item{schema}{A text string for the database schema name.}
+\item{schema}{Character, the database schema name.}
 
-\item{crs}{A character vector of the crscode(s) of the station(s)
+\item{crs}{Character vector of the crscode(s) of the station(s)
 for which a set of postcode choicesets is required.}
 
 \item{existing}{Logical. Indicates whether the station crscodes contained in
-\code{crs} are for existing (\code{TRUE}) or proposed (\code{FALSE}) stations.
-Default is \code{FALSE}.}
+\code{crs} are for existing (TRUE) or proposed (FALSE) stations.
+Default is FALSE.}
 
-\item{abs_crs}{Character. A single crs code of an existing station for which an
-after set of postcode choicesets is required. Optional.}
+\item{abs_crs}{Character, a single crs code of an existing station for which
+an after set of postcode choicesets is required. Optional.}
 }
 \value{
-Returns a data frame containing the postcode choicesets with stations ranked
-by distance.
+Returns a data frame containing the postcode choicesets with stations
+ranked by distance from the postcode centroid.
 }
 \description{
 For a given station or stations identifies the postcodes within 60 minutes of
-the station or stations and then generates a choice set of the nearest 10 stations to each of those
-postcodes. The function is also able to generate before and after choicesets for abstraction analysis.
+the station or stations and then generates a choice set of the nearest 10
+stations to each of those postcodes. The function is also able to generate
+before and after choicesets for abstraction analysis.
 }
 \details{
-If existing is set to \code{FALSE} then the crscodes in \code{crs} must be proposed
-stations. The function will obtain the 60 minute service area geometry from the
-modelschema.proposed_stations table. If there is more than one crscode in \code{crs} then
-st_union will be applied to the individual service area geometries to create a
-single merged 60 minute service area (this is used when the concurrent mode has
-been selected for the model run).
+If \code{existing} is set to FALSE then the crscode(s) in \code{crs} must be
+for proposed stations. The function obtains the 60 minute service area geometry
+from the schema.proposed_stations table. If there is more than one crscode in
+\code{crs} then st_union will be applied to the individual service area
+geometries to create a single merged 60 minute service area (this is used when
+the concurrent mode has been selected for the model run). The function uses
+parallel processing via the foreach package and requires the clusters to be
+configured prior to calling the function.
 
-If existing is set to \code{TRUE} then the crscodes in \code{crs} must be existing
-stations (normally a single station). The function will obtain the 60 minute service
-area geometry from the data.stations table.
+If \code{existing} is set to TRUE then the crscode(s) in \code{crs} must be
+existing stations (normally a single station). The function will obtain the
+60 minute service area geometry from the data.stations table.
 
 If \code{abs_crs} is passed to the function then it should be a single crscode
-of an existing station. This is used to control whether a before or after set of
-postcode choicesets is required. To obtain a before choiceset for abstraction analysis
-pass the existing station crscode to the function using \code{crs}, set \code{existing}
-to \code{TRUE} and do not pass \code{abs_crs}. To obtain an after choiceset for
-abstraction analysis pass the proposed station(s) in \code{crs}, set \code{existing}
-to \code{FALSE} and pass the crscode of the existing station for which abstraction analysis
-is being carried out to \code{abs_crs}.
+of an existing station. This is used to control whether a before or after set
+of postcode choicesets is required. To obtain a before choiceset for
+abstraction analysis pass the existing station crscode to the function using
+\code{crs}, set \code{existing} to TRUE and do not pass \code{abs_crs}. To
+obtain an after choiceset for abstraction analysis pass the proposed station(s)
+in \code{crs}, set \code{existing} to FALSE and pass the crscode of the
+existing station for which abstraction analysis is being carried out to
+\code{abs_crs}.
 
-The function uses parallel processing via the foreach package and requires
-the clusters to be configured prior to calling the function.
-
-The function submits db queries which rely on several pgRouting wrapper functions that must be
-located in the openroads schema: \code{create_pgr_vnodes},
+The function submits db queries which rely on several bespoke pgRouting wrapper
+functions that must be located in the openroads schema: \code{create_pgr_vnodes},
 \code{sdr_crs_pc_nearest_stationswithpoints}, \code{sdr_pc_station_withpoints},
 \code{sdr_pc_station_withpoints_nobbox}, and \code{bbox_pgr_withpointscost}.
 
-Two views are created for use by these functions. The first is modelschema.centroidnodes
-which is a union of virtual nodes for the proposed stations (which are created in the query)
-and virtual nodes for existing stations. The second is modelschema.stations which is a union of
-stations from data.stations and modelschema.proposed_stations containing the distance-based
-service areas used in identfying the nearest 10 stations to each postcode.
+Two views are created for use by these functions. The first is schema.centroidnodes
+which is a union of virtual nodes for the proposed stations (which are created
+in the query) and virtual nodes for existing stations. The second is
+schema.stations which is a union of stations from data.stations and
+schema.proposed_stations containing the distance-based service areas used in
+identfying the nearest 10 stations to each postcode.
 
 For maximum flexibility to also use this function for abstraction analysis
 without code repetition, it should be noted that the union queries are
-used even when \code{existing} is set to \code{TRUE} and the crscode in \code{crs} is
-an existing station. In this case there will be no match with the stations in
-modelschema.proposed_stations and that part of the union query will simply return null.
+used even when \code{existing} is set to TRUE and the crscode in \code{crs} is
+an existing station. In this case there will be no match with any stations in
+schema.proposed_stations and that part of the union query will simply return
+null.
 }

--- a/man/sdr_generate_probability_table.Rd
+++ b/man/sdr_generate_probability_table.Rd
@@ -2,21 +2,21 @@
 % Please edit documentation in R/sdr_generate_probability_table.R
 \name{sdr_generate_probability_table}
 \alias{sdr_generate_probability_table}
-\title{Creates and populates the probability table of a station}
+\title{Creates and populates the probability table for a station}
 \usage{
 sdr_generate_probability_table(schema, df, tablesuffix)
 }
 \arguments{
-\item{schema}{A text string for the database schema name.}
+\item{schema}{Character. for the database schema name.}
 
 \item{df}{A dataframe containing the choicesets.}
 
-\item{tablesuffix}{The suffix of the probability table - either crscode
-(isolation) or 'concurrent' (concurrent) is expected.}
+\item{tablesuffix}{Character, the suffix of the probability table - either
+crscode (isolation) or 'concurrent' (concurrent) is expected.}
 }
 \description{
-Creates and populates the probability table of a station (isolation)
+Creates and populates the probability table for a station (isolation)
 or stations (concurrent) with the variables required to apply
-the station choice model. The variables are drawn from the modelschema.proposed_stations
-and data.stations tables.
+the station choice model. The variables are drawn from the
+schema.proposed_stations and data.stations tables.
 }


### PR DESCRIPTION
1.	Improvements to loading input files
*	All now handled together in section of main script after preliminaries
*	Check that files exist and readable before attempting to import
*	New ‘path’ variable to set upper directory structure and to inject platform specific separator
*	Eastings and nothings forced to import as character vectors – ensures correct six figure reference can be input with leading zero when required. Converted to numeric later.
*	Force empty strings to import as NA
2.	Frequency groups now have their own input file – ‘freqgroups.csv’. As multiple groups can be specified it was not appropriate to have them in ‘config.csv’.
3.	New pre-flight check section. Performs all required checks on the input files. A failure will not stop the script until all checks are completed. This enables all the problems to be reported at the same time.  Some notable new checks are:
*	Easting and northing station and access locations fall within GB (database has new table in the data schema with the GB polygon)
* Exogenous inputs are correctly assigned to valid centroids
* Frequency group format and  supplied crscodes are valid
* Abstraction stations format and supplied crscodes are valid
4.	Generating service areas for proposed stations refactored:
* To avoid duplication when the same station is added multiple times for sensitivity testing, the service areas are now generated in a separate table called station_sas. The proposed_stations table is then updated from station_sas.
* Parallel processing is now used for this process.
* Associated changes to sdr_create_service_areas() to make it more flexible.
5.	Generating choicesets and probability tables refactored. Eliminates some remaining processing duplication.
6.	A number of bugs fixed, primarily related to not handling NAs correctly when present for optional values (such as frequency group and abstraction).
7. Change to decay function so it starts _decline_ after 750m but with distance reset to zero. Previous implementation applied decay to entire distance. Recalibrated trip end model parameters also now used.
8. Use sink() as workaround to enable logging with futile.logger within foreach parallel processing.

